### PR TITLE
Fix courtesy typo

### DIFF
--- a/src/utils/getWeightedOption.ts
+++ b/src/utils/getWeightedOption.ts
@@ -9,7 +9,7 @@ import { getRand } from "./random.js";
  *   ["blue", 50],
  * ]);
  * ```
- * Curtesy Mark Knol, T: @mknol (sourced from: https://github.com/liamegan/fxhash-helpers/blob/main/src/index.js)
+ * Courtesy Mark Knol, T: @mknol (sourced from: https://github.com/liamegan/fxhash-helpers/blob/main/src/index.js)
  * @param options - options in the format of [ [ string: optionName, int: optionNumber ] ]
  */
 const getWeightedOption = <T>(options: [T, number][]): T => {


### PR DESCRIPTION
## Summary
- fix a comment typo in `getWeightedOption`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f00a2e3f4832699e53b10bcd45e82