### PR TITLE
fix: add /ʒ/ to allowedFinal

### DIFF
--- a/src/config/english.ts
+++ b/src/config/english.ts
@@ -184,7 +184,7 @@ export const englishConfig: LanguageConfig = {
   codaConstraints: {
     allowedFinal: [
       "p", "b", "t", "d", "k", "g",
-      "f", "v", "s", "z", "ʃ",
+      "f", "v", "s", "z", "ʃ", "ʒ",
       "tʃ", "dʒ",
       "m", "n", "ŋ",
       "l", "r", "θ",


### PR DESCRIPTION
PR #42 mistakenly excluded /ʒ/ from `codaConstraints.allowedFinal`. English words like *beige*, *rouge*, *garage* end in /ʒ/. The grapheme ⟨ge⟩ already has `endWord: 1` so the writer handles it — only the repair pass was dropping it.

One-line fix.