### PR TITLE
fix: ngk→nk spelling rule (#49)

### DIFF
--- a/src/config/english.ts
+++ b/src/config/english.ts
@@ -172,6 +172,13 @@ export const englishConfig: LanguageConfig = {
       probability: 95,
       scope: "word",
     },
+    {
+      name: "ngk-to-nk",
+      pattern: "ng([kc])",
+      replacement: "n$1",
+      probability: 100,
+      scope: "word",
+    },
   ],
 
   clusterConstraint: {


### PR DESCRIPTION
## Summary

Adds a spelling rule to convert `ngk` and `ngc` sequences to `nk` and `nc`, matching English orthographic conventions.

Closes #49

## Change

One new entry in the `spellingRules` array in `src/config/english.ts`:

```typescript
{
  name: "ngk-to-nk",
  pattern: "ng([kc])",
  replacement: "n$1",
  probability: 100,
  scope: "word",
}
```

## Validation (50k word sample)

| Check | Result |
|-------|--------|
| `ngk` occurrences | **0** ✅ |
| `ngc` occurrences | **0** ✅ |
| `nk` still appears | **756 words** (e.g. "nulank", "pruhunk") ✅ |
| `ng` at word end | **5562 words** (e.g. "rotring") — not affected ✅ |
| `ngth` clusters | **212 words** (e.g. "sokength") — not affected ✅ |
| All existing tests | **65/65 passing** ✅ |