### PR TITLE
🦉 fix: normalize `ckt` → `ct` spelling (closes #72)

### DIFF
--- a/src/config/english.ts
+++ b/src/config/english.ts
@@ -186,6 +186,13 @@ export const englishConfig: LanguageConfig = {
       probability: 100,
       scope: "word",
     },
+    {
+      name: "ckt-to-ct",
+      pattern: "ckt",
+      replacement: "ct",
+      probability: 100,
+      scope: "word",
+    },
   ],
 
   clusterConstraint: {

--- a/src/core/quality.test.ts
+++ b/src/core/quality.test.ts
@@ -186,6 +186,10 @@ describe('Quality Benchmark', () => {
       expect(ngxCount).toBe(0);
     });
 
+    it('Gate: no ckt occurrences', () => {
+      expect(cktCount).toBe(0);
+    });
+
     it('Gate: bk < 50', () => {
       expect(bkCount).toBeLessThan(50);
     });


### PR DESCRIPTION
## Summary

Adds a spelling rule to normalize the unnatural `ckt` trigram to `ct`.

## Changes

- **`src/config/english.ts`**: Added `ckt-to-ct` spelling rule (pattern: `ckt` → `ct`, probability: 100%, scope: word)
- **`src/core/quality.test.ts`**: Added hard quality gate: `ckt = 0`

## Verification

- ✅ All 114 unit tests pass
- ✅ Quality gate: ckt drops to 0 occurrences

Closes #72