### PR TITLE
🦉 Fix #69: Block dk bigram via stop+stop voicing agreement at junctions

### DIFF
--- a/src/core/write.test.ts
+++ b/src/core/write.test.ts
@@ -119,6 +119,7 @@ const P_d = makePhoneme({ sound: 'd', mannerOfArticulation: 'stop', placeOfArtic
 const P_p = makePhoneme({ sound: 'p', mannerOfArticulation: 'stop', placeOfArticulation: 'bilabial' });
 const P_k = makePhoneme({ sound: 'k', mannerOfArticulation: 'stop', placeOfArticulation: 'velar' });
 const P_g = makePhoneme({ sound: 'g', mannerOfArticulation: 'stop', placeOfArticulation: 'velar', voiced: true });
+const P_b = makePhoneme({ sound: 'b', mannerOfArticulation: 'stop', placeOfArticulation: 'bilabial', voiced: true });
 const P_s = makePhoneme({ sound: 's', mannerOfArticulation: 'sibilant', placeOfArticulation: 'alveolar' });
 const P_ʃ = makePhoneme({ sound: 'ʃ', mannerOfArticulation: 'sibilant', placeOfArticulation: 'postalveolar' });
 const P_f = makePhoneme({ sound: 'f', mannerOfArticulation: 'fricative', placeOfArticulation: 'labiodental' });
@@ -247,6 +248,27 @@ describe('isJunctionValid', () => {
     });
     it('allows p→t (t is coronal)', () => {
       expect(isJunctionValid(P_p, P_t, [P_t])).toBe(true);
+    });
+  });
+
+  describe('F4: stop+stop voicing disagreement', () => {
+    it('rejects d→k (voiced+voiceless)', () => {
+      expect(isJunctionValid(P_d, P_k, [P_k])).toBe(false);
+    });
+    it('rejects b→t (voiced+voiceless)', () => {
+      expect(isJunctionValid(P_b, P_t, [P_t])).toBe(false);
+    });
+    it('rejects g→p (voiced+voiceless)', () => {
+      expect(isJunctionValid(P_g, P_p, [P_p])).toBe(false);
+    });
+    it('allows k→t (voiceless+voiceless)', () => {
+      expect(isJunctionValid(P_k, P_t, [P_t])).toBe(true);
+    });
+    it('allows g→d (voiced+voiced)', () => {
+      expect(isJunctionValid(P_g, P_d, [P_d])).toBe(true);
+    });
+    it('allows b→d (voiced+voiced)', () => {
+      expect(isJunctionValid(P_b, P_d, [P_d])).toBe(true);
     });
   });
 

--- a/src/core/write.ts
+++ b/src/core/write.ts
@@ -609,6 +609,9 @@ export function isJunctionValid(C1: Phoneme, C2: Phoneme, onsetCluster: Phoneme[
   // F3 also blocks affricate+stop where neither side is coronal — but all English affricates are coronal, so this is moot
   if (mannerGroup(C1) === 'stop' && mannerGroup(C2) === 'stop' && !isCoronal(C1) && !isCoronal(C2)) return false;
 
+  // F4: stop+stop voicing disagreement (blocks d.k, b.t, g.p etc.)
+  if (mannerGroup(C1) === 'stop' && mannerGroup(C2) === 'stop' && C1.voiced !== C2.voiced) return false;
+
   // P1: s-exception
   if (C1.sound === 's') return true;
   if (C2.sound === 's' && onsetCluster.length >= 2 && ['t','p','k'].includes(onsetCluster[1]?.sound)) return true;


### PR DESCRIPTION
Adds **F4** rule to `isJunctionValid()`: reject stop+stop pairs where voicing disagrees (e.g. d.k, b.t, g.p). Voiced+voiced and voiceless+voiceless stop clusters remain allowed.

- dk count dropped to 36 in quality benchmark (from previous levels)
- All 147 unit tests pass
- All 13 quality gates pass

Closes #69