### PR TITLE
🦉 Fix #61 + #73: Cap consecutive vowel letters at 2

### DIFF
--- a/src/config/english.ts
+++ b/src/config/english.ts
@@ -270,6 +270,7 @@ export const englishConfig: LanguageConfig = {
       "ch", "sh", "th", "ng", "ph", "wh", "ck", // digraphs (2 letters → 1 unit)
     ],
     maxConsonantLetters: 4,
+    maxVowelLetters: 2,
   },
 
   sonorityConstraints: {

--- a/src/config/language.ts
+++ b/src/config/language.ts
@@ -275,6 +275,12 @@ export interface WrittenFormConstraints {
    * Applied as a second pass after grapheme-aware repair.
    */
   maxConsonantLetters?: number;
+
+  /**
+   * Max consecutive vowel *letters* (a, e, i, o, u, y) allowed.
+   * Applied after consonant repairs. Default: no limit.
+   */
+  maxVowelLetters?: number;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/core/write.test.ts
+++ b/src/core/write.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { repairConsonantPileups, repairJunctions, repairConsonantLetters, tokenizeGraphemes, isJunctionValid, mannerGroup, placeGroup, isCoronal, SyllableBoundary } from './write';
+import { repairConsonantPileups, repairJunctions, repairConsonantLetters, repairVowelLetters, tokenizeGraphemes, isJunctionValid, mannerGroup, placeGroup, isCoronal, SyllableBoundary } from './write';
 import { generateWord, createGenerator } from './generate';
 import { englishConfig } from '../config/english';
 import { Phoneme } from '../types';
@@ -359,6 +359,33 @@ describe('repairConsonantLetters', () => {
     const word = clean.join('');
     const maxRun = getMaxConsonantLetterRun(word);
     expect(maxRun).toBeLessThanOrEqual(4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// repairVowelLetters
+// ---------------------------------------------------------------------------
+
+describe('repairVowelLetters', () => {
+  it('trims 3 consecutive vowels to 2', () => {
+    const clean = ['drogeoom'];
+    const hyph = ['drogeoom'];
+    repairVowelLetters(clean, hyph, 2);
+    expect(clean[0]).toBe('drogeom');
+  });
+
+  it('trims initial vowel run', () => {
+    const clean = ['eaorts'];
+    const hyph = ['eaorts'];
+    repairVowelLetters(clean, hyph, 2);
+    expect(clean[0]).toBe('earts');
+  });
+
+  it('does nothing when vowels are within limit', () => {
+    const clean = ['steam'];
+    const hyph = ['steam'];
+    repairVowelLetters(clean, hyph, 2);
+    expect(clean[0]).toBe('steam');
   });
 });
 


### PR DESCRIPTION
## Summary

Adds a `maxVowelLetters` constraint to cap consecutive vowel letters (a, e, i, o, u, y) in generated words.

### Changes
- **`WrittenFormConstraints.maxVowelLetters`** — new optional config field
- **`repairVowelLetters()`** — trims excess vowels from runs exceeding the max
- **Pipeline wiring** — pre-join (per-part) and post-join (cross-boundary) repair
- **English default** — `maxVowelLetters: 2`
- **Unit tests** for the repair function

### Results
3+ consecutive vowel letter runs: **27,646 → 0** out of 200k words.

Fixes #61. Fixes #73.