### PR TITLE
🦉 Fix #55: Remove redundant liquid/nasal onset heuristic

### DIFF
--- a/src/core/generate.ts
+++ b/src/core/generate.ts
@@ -285,13 +285,6 @@ function shouldStopClusterGrowth(context: ClusterContext, rt: GeneratorRuntime):
     }
   }
 
-  // Original heuristic: stop after liquid/nasal in onset
-  if (position === "onset" &&
-      cluster.length === 2 &&
-      ['liquid', 'nasal'].includes(cluster[1].mannerOfArticulation)) {
-    return true;
-  }
-
   return false;
 }
 


### PR DESCRIPTION
## Summary

Removes the hardcoded heuristic in `shouldStopClusterGrowth()` that stopped onset cluster growth after 2 consonants when the second was a liquid or nasal.

This check is redundant since PR #48 added the attested onset whitelist, which handles cluster validation properly. The old heuristic was rejecting valid clusters like `spl-`, `str-`, etc.

Closes #55

## Changes
- Removed 7-line block from `shouldStopClusterGrowth()` in `src/core/generate.ts`

## Testing
- ✅ All 148 unit tests pass
- ✅ All 13 quality benchmark gates pass (no regressions)