### PR TITLE
🦉 Fix #44: Move /h/ coda ban to codaConstraints

### DIFF
--- a/src/config/english.ts
+++ b/src/config/english.ts
@@ -44,9 +44,6 @@ const ENGLISH_BANNED_CLUSTERS: [string, string][] = [
   // /ð/ before stops
   ["ð", "p"], ["ð", "b"], ["ð", "t"], ["ð", "d"],
   ["ð", "k"], ["ð", "g"],
-  // /h/ should never be in coda
-  ["h", "p"], ["h", "b"], ["h", "t"], ["h", "d"],
-  ["h", "k"], ["h", "g"],
   // Same-place stop sequences
   ["p", "b"], ["b", "p"],
   ["t", "d"], ["d", "t"],
@@ -207,6 +204,7 @@ export const englishConfig: LanguageConfig = {
     repair: "drop-coda",
   },
   codaConstraints: {
+    bannedCodas: ["h"],
     allowedFinal: [
       "p", "b", "t", "d", "k", "g",
       "f", "v", "s", "z", "ʃ", "ʒ",

--- a/src/config/language.ts
+++ b/src/config/language.ts
@@ -13,6 +13,8 @@ export interface ClusterConstraint {
 export interface CodaConstraints {
   /** Phoneme sounds allowed in word-final position. Unlisted phonemes are dropped. */
   allowedFinal?: string[];
+  /** Phoneme sounds that must never appear in coda position (any syllable). */
+  bannedCodas?: string[];
   /** Require voicing agreement among obstruents in coda clusters. */
   voicingAgreement?: boolean;
   /** Require nasal+stop to agree in place of articulation. */

--- a/src/core/generate.ts
+++ b/src/core/generate.ts
@@ -29,6 +29,7 @@ interface GeneratorRuntime {
   bannedSet?: Set<string>;
   clusterRepair?: "drop-coda" | "drop-onset";
   allowedFinalSet?: Set<string>;
+  bannedCodaSet?: Set<string>;
   clusterLimits?: ClusterLimits;
   sonorityConstraints?: SonorityConstraints;
   codaAppendantSet?: Set<string>;
@@ -77,6 +78,9 @@ function buildRuntime(config: LanguageConfig): GeneratorRuntime {
     clusterRepair: config.clusterConstraint?.repair,
     allowedFinalSet: config.codaConstraints?.allowedFinal
       ? new Set(config.codaConstraints.allowedFinal)
+      : undefined,
+    bannedCodaSet: config.codaConstraints?.bannedCodas
+      ? new Set(config.codaConstraints.bannedCodas)
       : undefined,
     clusterLimits: cl,
     sonorityConstraints: sc,
@@ -129,6 +133,11 @@ function isValidCandidate(p: Phoneme, rt: GeneratorRuntime, context: ClusterCont
   if (context.ignore.includes(p.sound) ||
       context.cluster.some(existingP => existingP.sound === p.sound) ||
       !isValidPosition(p, context)) {
+    return false;
+  }
+
+  // Reject phonemes banned from coda position entirely
+  if (context.position === "coda" && rt.bannedCodaSet?.has(p.sound)) {
     return false;
   }
 


### PR DESCRIPTION
## Summary

Moves the /h/ coda ban from redundant banned cluster pairs to a proper `bannedCodas` field in `codaConstraints`.

### Changes

- **`src/config/language.ts`**: Add `bannedCodas?: string[]` field to `CodaConstraints` interface
- **`src/config/english.ts`**: Add `bannedCodas: ["h"]` and remove 6 redundant `["h", *]` banned cluster pairs
- **`src/core/generate.ts`**: Add `bannedCodaSet` to runtime, filter banned phonemes in `isValidCandidate()`

### Notes

/h/ already had `coda: 0` weight so it was never selected for codas via weighting. The banned cluster pairs were a redundant safety net. This PR replaces them with a cleaner, declarative `bannedCodas` mechanism that explicitly prevents banned phonemes from appearing in coda position regardless of weight.

All 151 unit tests and 13 quality benchmark tests pass.

Fixes #44