### PR TITLE
🦉 Fix #30: Refactor grapheme map-building into a function

### DIFF
--- a/src/elements/graphemes/index.ts
+++ b/src/elements/graphemes/index.ts
@@ -27,16 +27,16 @@ export const graphemes: Grapheme[] = [
   ...stopGraphemes,
 ];
 
-export const graphemeMaps = {
-  onset: new Map<string, Grapheme[]>(),
-  nucleus: new Map<string, Grapheme[]>(),
-  coda: new Map<string, Grapheme[]>()
+export type GraphemeMaps = {
+  onset: Map<string, Grapheme[]>;
+  nucleus: Map<string, Grapheme[]>;
+  coda: Map<string, Grapheme[]>;
 };
 
-export const cumulativeFrequencies = {
-  onset: new Map<string, number[]>(),
-  nucleus: new Map<string, number[]>(),
-  coda: new Map<string, number[]>()
+export type CumulativeFrequencies = {
+  onset: Map<string, number[]>;
+  nucleus: Map<string, number[]>;
+  coda: Map<string, number[]>;
 };
 
 /** Type-safe accessor for a grapheme's positional weight. */
@@ -48,20 +48,48 @@ function getPositionWeight(grapheme: Grapheme, position: 'onset' | 'nucleus' | '
   }
 }
 
-for (const position of ['onset', 'nucleus', 'coda'] as const) {
-  for (const grapheme of graphemes) {
-    const weight = getPositionWeight(grapheme, position);
-    if (weight === undefined || weight > 0) {
-      if (!graphemeMaps[position].has(grapheme.phoneme)) {
-        graphemeMaps[position].set(grapheme.phoneme, []);
-        cumulativeFrequencies[position].set(grapheme.phoneme, []);
+/**
+ * Build position-keyed grapheme maps and cumulative frequency tables
+ * from a flat array of graphemes. Extracted from the former top-level
+ * imperative loop so it can be tested and reused independently.
+ */
+export function buildGraphemeMaps(allGraphemes: Grapheme[]): {
+  graphemeMaps: GraphemeMaps;
+  cumulativeFrequencies: CumulativeFrequencies;
+} {
+  const graphemeMaps: GraphemeMaps = {
+    onset: new Map<string, Grapheme[]>(),
+    nucleus: new Map<string, Grapheme[]>(),
+    coda: new Map<string, Grapheme[]>()
+  };
+
+  const cumulativeFrequencies: CumulativeFrequencies = {
+    onset: new Map<string, number[]>(),
+    nucleus: new Map<string, number[]>(),
+    coda: new Map<string, number[]>()
+  };
+
+  for (const position of ['onset', 'nucleus', 'coda'] as const) {
+    for (const grapheme of allGraphemes) {
+      const weight = getPositionWeight(grapheme, position);
+      if (weight === undefined || weight > 0) {
+        if (!graphemeMaps[position].has(grapheme.phoneme)) {
+          graphemeMaps[position].set(grapheme.phoneme, []);
+          cumulativeFrequencies[position].set(grapheme.phoneme, []);
+        }
+        const graphemeList = graphemeMaps[position].get(grapheme.phoneme)!;
+        const frequencyList = cumulativeFrequencies[position].get(grapheme.phoneme)!;
+
+        graphemeList.push(grapheme);
+        const lastFreq = frequencyList.length > 0 ? frequencyList[frequencyList.length - 1] : 0;
+        frequencyList.push(lastFreq + grapheme.frequency);
       }
-      const graphemeList = graphemeMaps[position].get(grapheme.phoneme)!;
-      const frequencyList = cumulativeFrequencies[position].get(grapheme.phoneme)!;
-      
-      graphemeList.push(grapheme);
-      const lastFreq = frequencyList.length > 0 ? frequencyList[frequencyList.length - 1] : 0;
-      frequencyList.push(lastFreq + grapheme.frequency);
     }
   }
+
+  return { graphemeMaps, cumulativeFrequencies };
 }
+
+const { graphemeMaps: _maps, cumulativeFrequencies: _freqs } = buildGraphemeMaps(graphemes);
+export const graphemeMaps = _maps;
+export const cumulativeFrequencies = _freqs;


### PR DESCRIPTION
Closes #30

Extracts the top-level imperative `for` loops that build `graphemeMaps` and `cumulativeFrequencies` into an exported `buildGraphemeMaps()` function.

### Changes
- New exported `buildGraphemeMaps(allGraphemes)` function that returns `{ graphemeMaps, cumulativeFrequencies }`
- New exported types `GraphemeMaps` and `CumulativeFrequencies`
- Module-level exports preserved via destructured call to the new function
- All 151 tests pass, quality benchmark unchanged