### PR TITLE
fix: allow 2-letter words via relaxed length targets (#127)

### DIFF
--- a/src/config/weights.ts
+++ b/src/config/weights.ts
@@ -168,7 +168,7 @@ export const SYLLABLE_COUNT_WEIGHTS_LEXICON: [number, number][] = [
  * Used for rejection sampling to shape word-length distribution.
  */
 export const LETTER_LENGTH_TARGETS: Record<number, [number, number, number, number]> = {
-  1: [3, 3, 5, 7],
+  1: [2, 3, 5, 7],
   2: [3, 5, 7, 10],
   3: [5, 7, 10, 13],
   4: [7, 8, 12, 15],

--- a/src/core/generate.ts
+++ b/src/core/generate.ts
@@ -595,10 +595,6 @@ function generateOneWord(
       currSyllableIndex: 0,
     };
     runPipeline(rt, context, mode);
-    // Reject monosyllables shorter than 3 letters (kills "ra", "le", "da", etc.)
-    if (context.syllableCount === 1 && context.word.written.clean.length < 3 && attempt < MAX_LENGTH_RETRIES) {
-      continue;
-    }
     if (attempt === MAX_LENGTH_RETRIES || acceptLetterLength(rt, context)) {
       return context.word;
     }

--- a/src/core/quality.test.ts
+++ b/src/core/quality.test.ts
@@ -303,10 +303,10 @@ describe('Quality Benchmark', () => {
       expect(rengTengCount).toBeLessThan(150);
     });
 
-    it('Gate: 2-letter monosyllables ≤ 3% of all monosyllables', () => {
+    it('Gate: 2-letter monosyllables ≤ 8% of all monosyllables', () => {
       const pct = monoTwoLetterOrLess / monoTotal * 100;
       console.log(`2-letter mono: ${monoTwoLetterOrLess}/${monoTotal} (${pct.toFixed(1)}%)`);
-      expect(pct).toBeLessThanOrEqual(3);
+      expect(pct).toBeLessThanOrEqual(8);
     });
 
     it('Gate: open monosyllables ≤ 20% of all monosyllables', () => {


### PR DESCRIPTION
## Summary

PR #125 over-corrected monosyllable quality by completely banning 2-letter words (16%→0%). This restores them at a controlled rate.

## Changes

- **Remove hard 3-letter minimum** for monosyllables in `generate.ts`
- **Change letter-length targets** for 1-syllable from `[3,3,5,7]` to `[2,3,5,7]`
  - 2-letter words fall in `[min, peakMin)` → accepted 50% of the time
- **Update quality gate** from ≤3% to ≤8% for 2-letter monosyllables

## Results

- **Observed rate:** ~4-6% of monosyllables are 2-letter (was 0%, English types ~1%, tokens ~10-15%)
- **142 unique 2-letter forms** in a 50k sample — most match real English patterns (an, at, be, by, do, he, in, is, it, me, my, no, on, or, so, to, we)
- **All tests pass** (unit + quality gates)
- **hasCodaMonosyllabic stays at 90%** — most 2-letter words are closed (CVC minus one consonant)

See [linguistic analysis on #127](https://github.com/unglish/word-generator/issues/127#issuecomment-3887671600).

Closes #127