### PR TITLE
refactor: externalize stress config (#35, PR A)

### DIFF
--- a/src/config/english.ts
+++ b/src/config/english.ts
@@ -119,6 +119,19 @@ export const englishConfig: LanguageConfig = {
 
   stress: {
     strategy: "weight-sensitive",
+    disyllabicWeights: [70, 30],
+    polysyllabicWeights: {
+      heavyPenult: 70,
+      lightPenult: 30,
+      antepenult: 60,  // used when penultimate is light
+      initial: 10,
+    },
+    secondaryStressProbability: 40,
+    secondaryStressHeavyWeight: 70,
+    secondaryStressLightWeight: 30,
+    rhythmicStressProbability: 40,
+    stressedNucleusBan: ["ə"],
+    unstressedNucleusBoost: { "ə": 3 },
   },
 
   doubling: {

--- a/src/config/language.ts
+++ b/src/config/language.ts
@@ -172,6 +172,28 @@ export interface StressRules {
   strategy: "fixed" | "weight-sensitive" | "penultimate" | "initial" | "custom";
   /** For fixed strategy: 0-indexed syllable that receives primary stress */
   fixedPosition?: number;
+
+  /** Disyllabic primary stress: [firstSyllable, secondSyllable] weights. Default [70, 30] */
+  disyllabicWeights?: [number, number];
+  /** Polysyllabic primary stress weights */
+  polysyllabicWeights?: {
+    heavyPenult: number;
+    lightPenult: number;
+    antepenult: number;
+    initial: number;
+  };
+  /** Probability (0-100) of assigning secondary stress. Default 40 */
+  secondaryStressProbability?: number;
+  /** Heavy syllable weight for secondary stress candidates. Default 70 */
+  secondaryStressHeavyWeight?: number;
+  /** Light syllable weight for secondary stress candidates. Default 30 */
+  secondaryStressLightWeight?: number;
+  /** Probability (0-100) of rhythmic stress on eligible syllables. Default 40 */
+  rhythmicStressProbability?: number;
+  /** Phonemes banned from stressed nuclei (for future use). e.g. ["ə"] */
+  stressedNucleusBan?: string[];
+  /** Weight multipliers for unstressed nuclei (for future use). e.g. {"ə": 3} */
+  unstressedNucleusBoost?: Record<string, number>;
 }
 
 /**

--- a/src/core/generate.ts
+++ b/src/core/generate.ts
@@ -621,7 +621,7 @@ function runPipeline(rt: GeneratorRuntime, context: WordGenerationContext, mode:
   }
   repairNgCodaSibilant(context.word.syllables);
   rt.generateWrittenForm(context);
-  generatePronunciation(context, rt.config.vowelReduction);
+  generatePronunciation(context, rt.config.vowelReduction, rt.config.stress);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
PR A of the three-part stress pipeline refactor (#35).

Moves hardcoded stress assignment weights from pronounce.ts into the StressRules interface and englishConfig. Zero behavioral change — all values are extracted as-is.

Part of: #35
Next: PR B (move stress earlier in pipeline), PR C (stress-aware nucleus selection)