### PR TITLE
feat: externalize stress config (#35 PR A)

### DIFF
--- a/src/config/english.ts
+++ b/src/config/english.ts
@@ -119,6 +119,18 @@ export const englishConfig: LanguageConfig = {
 
   stress: {
     strategy: "weight-sensitive",
+    disyllabicWeights: [70, 30],
+    polysyllabicWeights: {
+      heavyPenult: 70,
+      lightPenult: 30,
+      antepenultHeavy: 20,
+      antepenultLight: 60,
+      initial: 10,
+    },
+    secondaryStressProbability: 40,
+    secondaryStressHeavyWeight: 70,
+    secondaryStressLightWeight: 30,
+    rhythmicStressProbability: 40,
   },
 
   doubling: {

--- a/src/config/language.ts
+++ b/src/config/language.ts
@@ -172,6 +172,45 @@ export interface StressRules {
   strategy: "fixed" | "weight-sensitive" | "penultimate" | "initial" | "custom";
   /** For fixed strategy: 0-indexed syllable that receives primary stress */
   fixedPosition?: number;
+
+  // -- Primary stress --
+
+  /** [firstSyllableWeight, secondSyllableWeight] for disyllabic words. Default: [70, 30]. */
+  disyllabicWeights?: [number, number];
+  /** Polysyllabic primary-stress weights by penultimate syllable weight. */
+  polysyllabicWeights?: {
+    /** Weight for penultimate when it is heavy. Default: 70. */
+    heavyPenult: number;
+    /** Weight for penultimate when it is light. Default: 30. */
+    lightPenult: number;
+    /** Weight for antepenultimate when penult is heavy. Default: 20. */
+    antepenultHeavy: number;
+    /** Weight for antepenultimate when penult is light. Default: 60. */
+    antepenultLight: number;
+    /** Weight for initial syllable (fallback). Default: 10. */
+    initial: number;
+  };
+
+  // -- Secondary stress --
+
+  /** Probability (0-100) of assigning secondary stress. Default: 40. */
+  secondaryStressProbability?: number;
+  /** Weight for heavy syllable candidates for secondary stress. Default: 70. */
+  secondaryStressHeavyWeight?: number;
+  /** Weight for light syllable candidates for secondary stress. Default: 30. */
+  secondaryStressLightWeight?: number;
+
+  // -- Rhythmic stress --
+
+  /** Probability (0-100) of assigning rhythmic secondary stress. Default: 40. */
+  rhythmicStressProbability?: number;
+
+  // -- Nucleus interaction (PR C) --
+
+  /** Phoneme sounds banned in stressed nuclei (e.g. ["ə"]). */
+  stressedNucleusBan?: string[];
+  /** Weight boosts for unstressed nuclei (e.g. {"ə": 3}). */
+  unstressedNucleusBoost?: Record<string, number>;
 }
 
 /**

--- a/src/core/generate.ts
+++ b/src/core/generate.ts
@@ -621,7 +621,7 @@ function runPipeline(rt: GeneratorRuntime, context: WordGenerationContext, mode:
   }
   repairNgCodaSibilant(context.word.syllables);
   rt.generateWrittenForm(context);
-  generatePronunciation(context, rt.config.vowelReduction);
+  generatePronunciation(context, rt.config.vowelReduction, rt.config.stress);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

PR A of 3 for #35 — externalizes hardcoded stress parameters from `pronounce.ts` into `LanguageConfig.stress` (`StressRules` interface).

### Changes

- **`src/config/language.ts`** — Extended `StressRules` with: `disyllabicWeights`, `polysyllabicWeights`, `secondaryStressProbability`, `secondaryStressHeavyWeight`, `secondaryStressLightWeight`, `rhythmicStressProbability`, `stressedNucleusBan`, `unstressedNucleusBoost`
- **`src/config/english.ts`** — Populated `englishConfig.stress` with the exact values previously hardcoded in pronounce.ts
- **`src/core/pronounce.ts`** — `applyStress()` and sub-functions now read from `StressRules` config instead of hardcoded numbers
- **`src/core/generate.ts`** — Passes `rt.config.stress` through to `generatePronunciation()`

### Zero behavioral change

All 195 tests pass unchanged. The config values are identical to the previously hardcoded values — this is a pure extraction refactor.

Refs: #35