### PR TITLE
feat: move stress earlier in pipeline (#35 PR B)

### DIFF
--- a/src/core/generate.ts
+++ b/src/core/generate.ts
@@ -3,7 +3,7 @@ import { RNG, createSeededRng, createDefaultRng } from "../utils/random.js";
 import getWeightedOption from "../utils/getWeightedOption.js";
 import { LanguageConfig, computeSonorityLevels, validateConfig, ClusterLimits, SonorityConstraints } from "../config/language.js";
 import { englishConfig } from "../config/english.js";
-import { generatePronunciation } from "./pronounce.js";
+import { applyStress, generatePronunciation } from "./pronounce.js";
 import { createWrittenFormGenerator } from "./write.js";
 import { repairClusters, repairFinalCoda, repairClusterShape, repairNgCodaSibilant } from "./repair.js";
 import type { GenerationWeights } from "../config/language.js";
@@ -620,8 +620,9 @@ function runPipeline(rt: GeneratorRuntime, context: WordGenerationContext, mode:
     });
   }
   repairNgCodaSibilant(context.word.syllables);
+  applyStress(context, rt.config.stress ?? { strategy: "weight-sensitive" });
   rt.generateWrittenForm(context);
-  generatePronunciation(context, rt.config.vowelReduction, rt.config.stress);
+  generatePronunciation(context, rt.config.vowelReduction);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/core/pronounce.ts
+++ b/src/core/pronounce.ts
@@ -73,7 +73,7 @@ const aspirateSyllable = (position: number, context: WordGenerationContext): voi
     }
   }
 };
-const applyStress = (context: WordGenerationContext, stress: StressRules): void => {
+export const applyStress = (context: WordGenerationContext, stress: StressRules): void => {
   const { rand } = context;
   // Rule 1: Primary stress 
   applyPrimaryStress(context, rand, stress);
@@ -272,13 +272,11 @@ export const _reduceUnstressedVowels = reduceUnstressedVowels;
 export const generatePronunciation = (
   context: WordGenerationContext,
   vowelReduction?: VowelReductionConfig,
-  stress?: StressRules,
 ): void => {
   const syllables = context.word.syllables;
   for (let i = 0; i < syllables.length; i++) {
     aspirateSyllable(i, context);
   }
-  applyStress(context, stress ?? { strategy: "weight-sensitive" });
   if (vowelReduction?.enabled) {
     reduceUnstressedVowels(context, vowelReduction, context.rand);
   }


### PR DESCRIPTION
## Pipeline Reorder — Stress Assignment (#35 PR B)

Moves `applyStress()` out of `generatePronunciation()` and into `runPipeline()`, running it **after** `repairNgCodaSibilant()` but **before** `generateWrittenForm()`.

### New pipeline order:
```
generateSyllables → repairClusters → repairFinalCoda → repairClusterShape → repairNgCodaSibilant → applyStress → generateWrittenForm → generatePronunciation
```

### Why:
- Stress assignment is a phonological property that should be settled before written form generation
- **Aspiration fix bonus**: `aspirateSyllable()` reads `syllable.stress`, which was always undefined before stress assignment ran. Now stress is assigned first, so aspiration in `generatePronunciation()` sees correct stress values.

### Changes:
- `src/core/pronounce.ts`: Export `applyStress`, remove it and `stress` param from `generatePronunciation()`
- `src/core/generate.ts`: Import `applyStress`, call it in pipeline before written form generation

All 195 tests pass. Near-zero behavioral change.

Refs #35