### PR TITLE
fix: post-/s/ aspiration early-return (#138)

### DIFF
--- a/src/core/pronounce.ts
+++ b/src/core/pronounce.ts
@@ -19,11 +19,15 @@ const aspirateSyllable = (position: number, context: WordGenerationContext): voi
 
   let shouldAspirate = false;
 
-  // Don't aspirate if the previous syllable ends with 's'
+  // Post-/s/ stops are unaspirated in English (e.g. "spin", "stop").
+  // Early-return so position-based rates don't overwrite the 5% rate.
   if (position > 0) {
     const prevSyllable = word.syllables[position - 1];
     if (prevSyllable.coda.length > 0 && prevSyllable.coda[prevSyllable.coda.length - 1].sound === 's') {
-      shouldAspirate = getWeightedOption([[true, 5], [false, 95]], rand);
+      if (getWeightedOption([[true, 5], [false, 95]], rand)) {
+        syllable.onset[0] = { ...syllable.onset[0], aspirated: true };
+      }
+      return;
     }
   }
 


### PR DESCRIPTION
Post-/s/ stops should be unaspirated in English (e.g. 'spin', 'stop'). The 5% aspiration rate was being overwritten by position-based rates (90% stressed, 30% default, etc.) because the post-/s/ check didn't early-return.

Fix: early-return after the post-/s/ branch fires, applying onset aspiration directly.

Closes #138.