### PR TITLE
feat: add ou → /ʊ/ grapheme (#96)

### DIFF
--- a/src/elements/graphemes/vowels.ts
+++ b/src/elements/graphemes/vowels.ts
@@ -335,6 +335,16 @@ export const vowelGraphemes: Grapheme[] = [
     midWord: 1,
     endWord: 1,
   },
+  // could, would, should, courier
+  {
+    phoneme: "ʊ",
+    form: "ou",
+    origin: 1,
+    frequency: 8,
+    startWord: 0,
+    midWord: 5,
+    endWord: 0,
+  },
 
   // blue
   {


### PR DESCRIPTION
Adds `ou` as a grapheme for /ʊ/ (the vowel in could, would, should, courier).

- Frequency 8 (low — `oo` and `u` remain dominant for /ʊ/)
- Mid-word only (`startWord: 0`, `endWord: 0`) matching English distribution
- ~0.3% of generated words now use this spelling

All 204 tests pass.

Closes #96.