### PR TITLE
fix: initial-letter distribution tuning (#52)

### DIFF
--- a/src/config/weights.ts
+++ b/src/config/weights.ts
@@ -110,7 +110,7 @@ export const BOUNDARY_DROP_CHANCE = 90;
 // ---------------------------------------------------------------------------
 
 /** Chance (out of 100) that the first syllable has an onset. */
-export const HAS_ONSET_START_OF_WORD = 95;
+export const HAS_ONSET_START_OF_WORD = 85;
 
 /** Chance (out of 100) that a non-initial syllable has an onset when the previous syllable has a coda. */
 export const HAS_ONSET_AFTER_CODA = 80;

--- a/src/elements/graphemes/stops.ts
+++ b/src/elements/graphemes/stops.ts
@@ -114,7 +114,7 @@ export const stopGraphemes: Grapheme[] = [
     origin: 3, 
     frequency: 100,
     cluster: 100,
-    startWord: 1,
+    startWord: 15,
     midWord: 1,
     endWord: 0,
     condition: { notRightContext: ["c-soft-vowel"] },

--- a/src/elements/phonemes.ts
+++ b/src/elements/phonemes.ts
@@ -58,19 +58,19 @@ export const phonemes: Phoneme[] = [
   { sound: "ɪ", mannerOfArticulation: "highVowel", tense: false, nucleus: 230, startWord: 3, midWord: 8, endWord: 1, voiced: true, placeOfArticulation: "front" }, // sit
 
   // Mid Vowels
-  { sound: "e", mannerOfArticulation: "midVowel", tense: false, nucleus: 140, startWord: 8, midWord: 2, endWord: 1, voiced: true, placeOfArticulation: "front" }, // red
-  { sound: "ɛ", mannerOfArticulation: "midVowel", tense: false, nucleus: 280, startWord: 8, midWord: 2, endWord: 1, voiced: true, placeOfArticulation: "front" }, // let
+  { sound: "e", mannerOfArticulation: "midVowel", tense: false, nucleus: 140, startWord: 3, midWord: 2, endWord: 1, voiced: true, placeOfArticulation: "front" }, // red
+  { sound: "ɛ", mannerOfArticulation: "midVowel", tense: false, nucleus: 280, startWord: 3, midWord: 2, endWord: 1, voiced: true, placeOfArticulation: "front" }, // let
   { sound: "ə", mannerOfArticulation: "midVowel", tense: false, nucleus: 330, startWord: 4, midWord: 8, endWord: 1, voiced: true, placeOfArticulation: "central" }, // the
   { sound: "ɜ", mannerOfArticulation: "midVowel", tense: false, nucleus: 50, startWord: 4, midWord: 2, endWord: 1, voiced: true, placeOfArticulation: "central" }, // bed, said, execute
   { sound: "ɚ", mannerOfArticulation: "midVowel", tense: false, nucleus: 90, startWord: 1, midWord: 2, endWord: 5, voiced: true, placeOfArticulation: "central" }, // her, letter
 
   // Low Vowels
-  { sound: "æ", mannerOfArticulation: "lowVowel", tense: false, nucleus: 220, startWord: 8, midWord: 6, endWord: 1, voiced: true, placeOfArticulation: "front" }, // apple, hat, map
+  { sound: "æ", mannerOfArticulation: "lowVowel", tense: false, nucleus: 220, startWord: 12, midWord: 6, endWord: 1, voiced: true, placeOfArticulation: "front" }, // apple, hat, map
   { sound: "ɑ", mannerOfArticulation: "lowVowel", tense: true, nucleus: 150, startWord: 6, midWord: 2, endWord: 1, voiced: true, placeOfArticulation: "back" }, // father
   { sound: "ɔ", mannerOfArticulation: "lowVowel", tense: true, nucleus: 80, startWord: 6, midWord: 2, endWord: 1, voiced: true, placeOfArticulation: "back" }, // ball
   { sound: "o", mannerOfArticulation: "lowVowel", tense: true, nucleus: 100, startWord: 6, midWord: 2, endWord: 2, voiced: true, placeOfArticulation: "back" }, // hope
   { sound: "ʊ", mannerOfArticulation: "highVowel", tense: true, nucleus: 70, startWord: 4, midWord: 2, endWord: 0, voiced: true, placeOfArticulation: "back" }, // book
-  { sound: "u", mannerOfArticulation: "highVowel", tense: true, nucleus: 80, startWord: 8, midWord: 2, endWord: 2, voiced: true, placeOfArticulation: "back" }, // blue
+  { sound: "u", mannerOfArticulation: "highVowel", tense: true, nucleus: 80, startWord: 4, midWord: 2, endWord: 2, voiced: true, placeOfArticulation: "back" }, // blue
   { sound: "ʌ", mannerOfArticulation: "midVowel", tense: false, nucleus: 120, startWord: 4, midWord: 2, endWord: 1, voiced: true, placeOfArticulation: "central" }, // cup
 
   // Diphthongs (typically treated as mid or low vowels)
@@ -95,16 +95,16 @@ export const phonemes: Phoneme[] = [
   { sound: "w", mannerOfArticulation: "glide", onset: 120, coda: 10, startWord: 10, midWord: 2, endWord: 2, voiced: true, placeOfArticulation: "labial-velar" }, // wow
 
   // Liquids
-  { sound: "l", mannerOfArticulation: "liquid", onset: 200, coda: 200, startWord: 8, midWord: 5, endWord: 8, voiced: true, placeOfArticulation: "alveolar" }, // lid
-  { sound: "r", mannerOfArticulation: "liquid", onset: 300, coda: 100, startWord: 8, midWord: 2, endWord: 8, voiced: true, placeOfArticulation: "postalveolar" }, // rank
+  { sound: "l", mannerOfArticulation: "liquid", onset: 200, coda: 200, startWord: 5, midWord: 5, endWord: 8, voiced: true, placeOfArticulation: "alveolar" }, // lid
+  { sound: "r", mannerOfArticulation: "liquid", onset: 300, coda: 100, startWord: 4, midWord: 2, endWord: 8, voiced: true, placeOfArticulation: "postalveolar" }, // rank
 
   // Nasals
-  { sound: "m", mannerOfArticulation: "nasal", onset: 100, coda: 176, startWord: 6, midWord: 2, endWord: 8, voiced: true, placeOfArticulation: "bilabial" }, // mouse
-  { sound: "n", mannerOfArticulation: "nasal", onset: 350, coda: 350, startWord: 8, midWord: 2, endWord: 10, voiced: true, placeOfArticulation: "alveolar" }, // notice
+  { sound: "m", mannerOfArticulation: "nasal", onset: 100, coda: 176, startWord: 12, midWord: 2, endWord: 8, voiced: true, placeOfArticulation: "bilabial" }, // mouse
+  { sound: "n", mannerOfArticulation: "nasal", onset: 350, coda: 350, startWord: 3, midWord: 2, endWord: 10, voiced: true, placeOfArticulation: "alveolar" }, // notice
   { sound: "ŋ", mannerOfArticulation: "nasal", onset: 0, coda: 40, startWord: 0, midWord: 2, endWord: 30, voiced: true, placeOfArticulation: "velar" }, // bring
 
   // Voiceless Fricatives
-  { sound: "f", mannerOfArticulation: "fricative", onset: 100, coda: 100, startWord: 6, midWord: 2, endWord: 4, voiced: false, placeOfArticulation: "labiodental" }, // fish
+  { sound: "f", mannerOfArticulation: "fricative", onset: 100, coda: 100, startWord: 14, midWord: 2, endWord: 4, voiced: false, placeOfArticulation: "labiodental" }, // fish
   { sound: "θ", mannerOfArticulation: "fricative", onset: 50, coda: 50, startWord: 4, midWord: 2, endWord: 4, voiced: false, placeOfArticulation: "dental" }, // think
   { sound: "h", mannerOfArticulation: "fricative", onset: 180, coda: 0, startWord: 10, midWord: 2, endWord: 0, voiced: false, placeOfArticulation: "glottal" }, // he
 
@@ -113,7 +113,7 @@ export const phonemes: Phoneme[] = [
   { sound: "ð", mannerOfArticulation: "fricative", onset: 250, coda: 50, startWord: 6, midWord: 2, endWord: 4, voiced: true, placeOfArticulation: "dental" }, // this
 
   // Sibilants
-  { sound: "z", mannerOfArticulation: "sibilant", onset: 25, coda: 50, startWord: 4, midWord: 4, endWord: 4, voiced: true, placeOfArticulation: "alveolar" }, // zebra
+  { sound: "z", mannerOfArticulation: "sibilant", onset: 25, coda: 50, startWord: 2, midWord: 4, endWord: 4, voiced: true, placeOfArticulation: "alveolar" }, // zebra
   { sound: "ʒ", mannerOfArticulation: "sibilant", onset: 5, coda: 3, startWord: 0, midWord: 6, endWord: 0, voiced: true, placeOfArticulation: "postalveolar" }, // measure
   { sound: "s", mannerOfArticulation: "sibilant", onset: 200, coda: 100, startWord: 10, midWord: 2, endWord: 10, voiced: false, placeOfArticulation: "alveolar" }, // see
   { sound: "ʃ", mannerOfArticulation: "sibilant", onset: 35, coda: 80, startWord: 4, midWord: 1, endWord: 5, voiced: false, placeOfArticulation: "postalveolar" }, // she
@@ -124,12 +124,12 @@ export const phonemes: Phoneme[] = [
 
   // Voiceless Stops
   { sound: "p", voiced: false, placeOfArticulation: "bilabial", mannerOfArticulation: "stop", onset: 100, coda: 50, startWord: 8, midWord: 10, endWord: 6 }, // pop
-  { sound: "t", voiced: false, placeOfArticulation: "alveolar", mannerOfArticulation: "stop", onset: 350, coda: 350, startWord: 10, midWord: 10, endWord: 10 }, // top
-  { sound: "k", voiced: false, placeOfArticulation: "velar", mannerOfArticulation: "stop", onset: 160, coda: 100, startWord: 14, midWord: 10, endWord: 10 }, // cat
+  { sound: "t", voiced: false, placeOfArticulation: "alveolar", mannerOfArticulation: "stop", onset: 350, coda: 350, startWord: 5, midWord: 10, endWord: 10 }, // top
+  { sound: "k", voiced: false, placeOfArticulation: "velar", mannerOfArticulation: "stop", onset: 160, coda: 100, startWord: 4, midWord: 10, endWord: 10 }, // cat
 
   // Voiced Stops
-  { sound: "b", voiced: true, placeOfArticulation: "bilabial", mannerOfArticulation: "stop", onset: 100, coda: 100, startWord: 8, midWord: 4, endWord: 4 }, // bob
-  { sound: "d", voiced: true, placeOfArticulation: "alveolar", mannerOfArticulation: "stop", onset: 210, coda: 210, startWord: 8, midWord: 4, endWord: 8 }, // dog
+  { sound: "b", voiced: true, placeOfArticulation: "bilabial", mannerOfArticulation: "stop", onset: 100, coda: 100, startWord: 14, midWord: 4, endWord: 4 }, // bob
+  { sound: "d", voiced: true, placeOfArticulation: "alveolar", mannerOfArticulation: "stop", onset: 210, coda: 210, startWord: 5, midWord: 4, endWord: 8 }, // dog
   { sound: "g", voiced: true, placeOfArticulation: "velar", mannerOfArticulation: "stop", onset: 50, coda: 100, startWord: 6, midWord: 4, endWord: 4 }, // go
 ];
 


### PR DESCRIPTION
## Initial-Letter Distribution Tuning

Fixes #52, relates to #115

### Approach

Uses `startWord` positional weights to tune word-initial letter frequencies **without changing overall phoneme frequency**. The `startWord` multiplier only affects word-initial position, making it a surgical tool for this purpose.

Also adjusted:
- `HAS_ONSET_START_OF_WORD`: 95→85 (more vowel-initial words, closer to English ~20%)
- `"c"` grapheme `startWord`: 1→15 (strongly prefer "c" over "k" spelling before back vowels)

### Changes

**Phoneme `startWord` adjustments:**
| Phoneme | Before | After | Rationale |
|---------|--------|-------|-----------|
| /k/ | 14 | 4 | Was massively over-represented |
| /n/ | 8 | 3 | onset:350 already very high |
| /r/ | 8 | 4 | onset:300 already very high |
| /t/ | 10 | 5 | onset:350 already very high |
| /l/ | 8 | 5 | Was 2.3× over |
| /d/ | 8 | 5 | Was 1.9× over |
| /b/ | 8 | 14 | Was 0.6× under |
| /m/ | 6 | 12 | Was 0.5× under |
| /f/ | 6 | 14 | Was 0.5× under |
| /æ/ | 8 | 12 | Boost "a"-initial words |
| /e/ | 8 | 3 | Too many "e"-initial after vowel boost |
| /ɛ/ | 8 | 3 | Same |
| /u/ | 8 | 4 | Was 2.9× over |
| /z/ | 4 | 2 | Was 3.5× over |

### Before (200k sample on main)
```
k: 8.7× over    n: 4.7× over    r: 3.5× over
t: 1.9× over    a: 0.4× under   c: 0.4× under
f: 0.5× under   m: 0.5× under   b: 0.6× under
```

### After (50k sample)
```
t: 1.5×  a: 0.9×  s: 1.4×  h: 1.6×  b: 1.3×
f: 1.3×  e: 2.6×  r: 2.0×  w: 1.2×  m: 1.2×
n: 2.0×  d: 1.2×  l: 1.6×  i: 1.4×  p: 1.1×
o: 1.1×  k: 2.7×  v: 1.8×  u: 2.1×  g: 0.8×
c: 0.2×  j: 0.6×  y: 0.4×  z: 1.8×  q: 0.1×
```

### Known limitation: "c" remains under-represented (0.2×)

This is an **architectural limitation**, not a tuning issue. English c-softening rules require "k" before front vowels (i, e) and "c" before back vowels (a, o, u). Since nucleus selection is independent of onset selection, ~40% of /k/-initial words get front vowels and must spell as "k". In English, "c"-initial words heavily favour back vowels (cat, can, come, etc.), but our generator cannot bias nucleus selection based on onset. This would require architectural changes tracked separately.

### Test results
- ✅ 204/204 unit tests pass
- ✅ 25/25 quality benchmark tests pass
- ✅ Phonotactic gap improved: 0.62 (baseline: 0.85)
- ✅ Letter frequency correlation: r=0.882