### PR TITLE
feat: Germanic initial-stress bias (#13)

### DIFF
--- a/src/config/english.ts
+++ b/src/config/english.ts
@@ -119,13 +119,13 @@ export const englishConfig: LanguageConfig = {
 
   stress: {
     strategy: "weight-sensitive",
-    disyllabicWeights: [70, 30],
+    disyllabicWeights: [75, 25],
     polysyllabicWeights: {
-      heavyPenult: 70,
-      lightPenult: 30,
-      antepenultHeavy: 20,
-      antepenultLight: 60,
-      initial: 10,
+      heavyPenult: 45,
+      lightPenult: 25,
+      antepenultHeavy: 15,
+      antepenultLight: 30,
+      initial: 30,
     },
     secondaryStressProbability: 40,
     secondaryStressHeavyWeight: 70,


### PR DESCRIPTION
## Germanic Initial-Stress Bias

Adjusts polysyllabic and disyllabic stress weights to reflect English's Germanic initial-stress pattern.

### Linguistic Rationale
English stress is approximately 60% initial (Germanic inheritance) and 40% weight-sensitive (Romance/Latin borrowings). The previous weights produced Romance-flavored penultimate stress with only 10 weight for initial stress.

### Changes
**`polysyllabicWeights`:**
| Weight | Before | After |
|--------|--------|-------|
| heavyPenult | 70 | 45 |
| lightPenult | 30 | 25 |
| antepenultHeavy | 20 | 15 |
| antepenultLight | 60 | 30 |
| initial | 10 | **30** |

**`disyllabicWeights`:** `[70, 30]` → `[75, 25]` (English disyllabic words are ~75% initial-stress)

### Stress Distribution (10k words, seed 42, 3+ syllables)
- **Before:** 48.5% initial stress (783/1613)
- **After:** 58.9% initial stress (980/1665)

### Verification
- ✅ All 204 unit tests pass
- ✅ All 25 quality benchmark tests pass

Closes #13