### PR TITLE
🦉 Fix /nd/ coda suppression (#162)

### DIFF
--- a/scripts/nd-diagnostic.mjs
+++ b/scripts/nd-diagnostic.mjs
@@ -1,0 +1,73 @@
+import { generateWords } from '../dist/index.js';
+
+const N = 50000;
+const words = generateWords(N, { seed: 42 });
+
+// Count bigrams
+const bigramCounts = {};
+let totalBigrams = 0;
+
+for (const w of words) {
+  const text = w.written.clean.toLowerCase();
+  for (let i = 0; i < text.length - 1; i++) {
+    const bg = text[i] + text[i+1];
+    bigramCounts[bg] = (bigramCounts[bg] || 0) + 1;
+    totalBigrams++;
+  }
+}
+
+const nd = bigramCounts['nd'] || 0;
+console.log(`ND: ${nd}/${totalBigrams} = ${(nd/totalBigrams*100).toFixed(3)}%`);
+
+// Also check syllable structure
+let codaLen2Plus = 0;
+let codaStartsN = 0;
+let codaNd = 0;
+let totalSyllables = 0;
+
+for (const w of words) {
+  for (const syl of w.syllables) {
+    totalSyllables++;
+    if (syl.coda.length >= 2) {
+      codaLen2Plus++;
+      if (syl.coda[0].sound === 'n') {
+        codaStartsN++;
+        if (syl.coda.length >= 2 && syl.coda[1].sound === 'd') {
+          codaNd++;
+        }
+      }
+    }
+  }
+}
+
+console.log(`Total syllables: ${totalSyllables}`);
+console.log(`Coda len >= 2: ${codaLen2Plus} (${(codaLen2Plus/totalSyllables*100).toFixed(2)}%)`);
+console.log(`Coda starts /n/: ${codaStartsN} (${(codaStartsN/codaLen2Plus*100).toFixed(2)}% of len>=2)`);
+console.log(`Coda /nd/: ${codaNd} (${(codaNd/codaStartsN*100).toFixed(2)}% of /n/-initial codas)`);
+
+// Check what follows /n/ in codas
+const nFollowers = {};
+for (const w of words) {
+  for (const syl of w.syllables) {
+    if (syl.coda.length >= 2 && syl.coda[0].sound === 'n') {
+      const next = syl.coda[1].sound;
+      nFollowers[next] = (nFollowers[next] || 0) + 1;
+    }
+  }
+}
+console.log('\nWhat follows /n/ in codas:', nFollowers);
+
+// Check boundary drops - how many mid-word nd codas survive
+let midWordNd = 0;
+let endWordNd = 0;
+for (const w of words) {
+  for (let i = 0; i < w.syllables.length; i++) {
+    const syl = w.syllables[i];
+    const isEnd = i === w.syllables.length - 1;
+    if (syl.coda.length >= 2 && syl.coda[0].sound === 'n' && syl.coda[1].sound === 'd') {
+      if (isEnd) endWordNd++;
+      else midWordNd++;
+    }
+  }
+}
+console.log(`\n/nd/ codas: end-of-word=${endWordNd}, mid-word=${midWordNd}`);

--- a/scripts/nd-diagnostic2.mjs
+++ b/scripts/nd-diagnostic2.mjs
@@ -1,0 +1,30 @@
+import { generateWords } from '../dist/index.js';
+
+const N = 50000;
+const words = generateWords(N, { seed: 42 });
+
+// Count single-phoneme codas at end of word
+let endWordCodaLen1 = {};
+let endWordCodaLen1Total = 0;
+
+for (const w of words) {
+  const lastSyl = w.syllables[w.syllables.length - 1];
+  if (lastSyl.coda.length === 1) {
+    const s = lastSyl.coda[0].sound;
+    endWordCodaLen1[s] = (endWordCodaLen1[s] || 0) + 1;
+    endWordCodaLen1Total++;
+  }
+}
+
+// Sort by count
+const sorted = Object.entries(endWordCodaLen1).sort((a,b) => b[1] - a[1]);
+console.log(`End-of-word coda len=1 total: ${endWordCodaLen1Total}`);
+console.log('Top sounds:');
+for (const [s, c] of sorted.slice(0, 15)) {
+  console.log(`  ${s}: ${c} (${(c/endWordCodaLen1Total*100).toFixed(1)}%)`);
+}
+
+// How many /n/ len-1 codas at end of word?
+const nCount = endWordCodaLen1['n'] || 0;
+console.log(`\n/n/ singleton codas at end-of-word: ${nCount}`);
+console.log(`If 30% of these extended to /nd/, that adds ${Math.round(nCount * 0.3)} /nd/ codas`);

--- a/src/config/english.ts
+++ b/src/config/english.ts
@@ -29,6 +29,7 @@ import {
   CODA_LENGTH_POLYSYLLABIC_NONZERO,
   FINAL_S_CHANCE,
   BOUNDARY_DROP_CHANCE,
+  NASAL_STOP_EXTENSION_CHANCE,
   HAS_ONSET_START_OF_WORD,
   HAS_ONSET_AFTER_CODA,
   HAS_CODA_MONOSYLLABIC,
@@ -127,6 +128,7 @@ export const englishConfig: LanguageConfig = {
       hasCodaMidWord: HAS_CODA_MID_WORD,
       finalS: FINAL_S_CHANCE,
       boundaryDrop: BOUNDARY_DROP_CHANCE,
+      nasalStopExtension: NASAL_STOP_EXTENSION_CHANCE,
     },
   },
 

--- a/src/config/language.ts
+++ b/src/config/language.ts
@@ -157,6 +157,11 @@ export interface GenerationWeights {
     finalS: number;
     /** Chance to drop a coda phoneme at a syllable boundary with equal sonority. */
     boundaryDrop: number;
+    /**
+     * Chance (0–100) to extend a word-final singleton nasal coda with its
+     * voiced homorganic stop (n→nd, m→mb, ŋ→ŋg).  Default: 0 (disabled).
+     */
+    nasalStopExtension?: number;
   };
 }
 

--- a/src/config/weights.ts
+++ b/src/config/weights.ts
@@ -106,6 +106,16 @@ export const FINAL_S_CHANCE = 15;
 export const BOUNDARY_DROP_CHANCE = 90;
 
 // ---------------------------------------------------------------------------
+// Nasal + homorganic stop extension
+// ---------------------------------------------------------------------------
+
+/**
+ * Chance (out of 100) that a word-final singleton nasal coda is extended
+ * with its voiced homorganic stop (n → nd, m → mb, ŋ → ŋg).
+ */
+export const NASAL_STOP_EXTENSION_CHANCE = 24;
+
+// ---------------------------------------------------------------------------
 // Onset / coda presence probabilities
 // ---------------------------------------------------------------------------
 

--- a/src/core/generate.ts
+++ b/src/core/generate.ts
@@ -388,6 +388,19 @@ function pickCoda(rt: GeneratorRuntime, context: WordGenerationContext, newSylla
     maxLength,
   });
 
+  // Extend word-final singleton nasal codas with their voiced homorganic stop
+  const nasalExt = probability.nasalStopExtension ?? 0;
+  if (isEndOfWord && nasalExt > 0 && coda.length === 1 &&
+      coda[0].mannerOfArticulation === "nasal" &&
+      getWeightedOption([[true, nasalExt], [false, 100 - nasalExt]], rand)) {
+    const nasalSound = coda[0].sound;
+    const stopSound = nasalSound === "n" ? "d" : nasalSound === "m" ? "b" : nasalSound === "ŋ" ? "g" : null;
+    if (stopSound) {
+      const stopPhoneme = rt.config.phonemes.find(p => p.sound === stopSound);
+      if (stopPhoneme) coda.push(stopPhoneme);
+    }
+  }
+
   // Add 's' to the end of the last syllable occasionally
   if (isEndOfWord && getWeightedOption([[true, probability.finalS], [false, 100 - probability.finalS]], rand)) {
     const sPhoneme = rt.config.phonemes.find(p => p.sound === 's');


### PR DESCRIPTION
## Problem

ND bigram was 0.13% vs English 1.35% (0.10×). The previous attempt (PR #164) tried boosting broad coda probability weights but only got ND to 0.21% while making TS worse.

## Root Cause

Diagnostic analysis revealed the problem is structural:
1. **Coda length ≥2 is rare at end-of-word** (~17% probability) — most codas are single consonants
2. **When length ≥2, /d/ competes unfavorably with /t/** (/t/ has 2× the selection weight)
3. **Mid-word /nd/ is killed by boundary drop** (90% chance) — only 9 out of 553 /nd/ codas survived mid-word

The combination means very few /nd/ codas are generated despite being in the attested coda list.

## Fix

Add a **nasal + homorganic stop extension** mechanism: when a word-final coda is a single nasal phoneme (/n/, /m/, /ŋ/), extend it with the voiced homorganic stop (/d/, /b/, /g/) with 24% probability.

This is phonologically motivated — nasal+stop clusters (and, end, hand, find, lamb, long) are among the most common coda patterns in English.

### Changes
- `src/config/weights.ts`: New `NASAL_STOP_EXTENSION_CHANCE = 24`
- `src/config/language.ts`: Add optional `nasalStopExtension` to probability weights interface
- `src/config/english.ts`: Wire the new constant
- `src/core/generate.ts`: Extension logic in `pickCoda()` — 10 lines

## Results (200k lexicon words)

| Metric | Before | After | Target |
|--------|--------|-------|--------|
| ND bigram | 0.13% | **0.44%** | ≥0.40% ✓ |
| TS bigram | 1.35% | **1.35%** | no regression ✓ |
| Letter r | 0.919 | **0.918** | ≥0.91 ✓ |
| Bigram r | 0.448 | **0.453** | ≥0.44 ✓ |

All 256 tests pass.

Closes #162