### PR TITLE
🦉 Reduce /ʌ/→uh grapheme frequency (#162)

### DIFF
--- a/src/elements/graphemes/vowels.ts
+++ b/src/elements/graphemes/vowels.ts
@@ -407,7 +407,7 @@ export const vowelGraphemes: Grapheme[] = [
     phoneme: "ʌ", 
     form: "uh", 
     origin: 0, 
-    frequency: 30,
+    frequency: 3,
     startWord: 1,
     midWord: 4,
     endWord: 1,


### PR DESCRIPTION
## Fix #5 from #162 — Reduce /ʌ/→`uh` grapheme frequency

The `/ʌ/→uh` grapheme had `frequency: 30`, producing an unrealistically high UH bigram. Reduced to `frequency: 3`.

### Before/After Metrics

| Metric | Before | After |
|--------|--------|-------|
| UH novel bigram | 0.487% | 0.423% |
| H letter | 5.25% (eng: 5.05%) | 5.21% (eng: 5.05%) |
| R letter | 5.72% (eng: 6.28%) | 5.69% (eng: 6.28%) |
| Letter r | 0.9224 | 0.9221 |
| Bigram r | 0.5056 | 0.5096 |

UH dropped modestly. Most remaining UH bigrams come from `u` vowel graphemes followed by `h`-initial consonant graphemes (cross-grapheme adjacency), not the `uh` grapheme itself. The direct `uh` grapheme contribution is now negligible at frequency 3.

All 256 tests pass. No regressions.