### PR TITLE
🦉 Reduce /æ/ nucleus weight (#162)

### DIFF
--- a/src/elements/phonemes.ts
+++ b/src/elements/phonemes.ts
@@ -65,7 +65,7 @@ export const phonemes: Phoneme[] = [
   { sound: "ɚ", mannerOfArticulation: "midVowel", tense: false, nucleus: 90, startWord: 1, midWord: 2, endWord: 5, voiced: true, placeOfArticulation: "central" }, // her, letter
 
   // Low Vowels
-  { sound: "æ", mannerOfArticulation: "lowVowel", tense: false, nucleus: 220, startWord: 12, midWord: 6, endWord: 1, voiced: true, placeOfArticulation: "front" }, // apple, hat, map
+  { sound: "æ", mannerOfArticulation: "lowVowel", tense: false, nucleus: 160, startWord: 12, midWord: 6, endWord: 1, voiced: true, placeOfArticulation: "front" }, // apple, hat, map
   { sound: "ɑ", mannerOfArticulation: "lowVowel", tense: true, nucleus: 150, startWord: 6, midWord: 2, endWord: 1, voiced: true, placeOfArticulation: "back" }, // father
   { sound: "ɔ", mannerOfArticulation: "lowVowel", tense: true, nucleus: 80, startWord: 6, midWord: 2, endWord: 1, voiced: true, placeOfArticulation: "back" }, // ball
   { sound: "o", mannerOfArticulation: "lowVowel", tense: true, nucleus: 100, startWord: 6, midWord: 2, endWord: 2, voiced: true, placeOfArticulation: "back" }, // hope


### PR DESCRIPTION
## Summary
Reduce /æ/ nucleus weight from 220 → 160 to bring letter A frequency closer to English.

Fixes item #9 from #162.

## Before → After
| Metric | Before | After | English |
|--------|--------|-------|---------|
| A letter | 11.38% | 10.45% | 8.04% |
| AT bigram | 2.41% | 2.20% | 1.49% |
| Letter r | 0.929 | 0.938 | — |
| Bigram r | 0.514 | 0.514 | — |

## Change
Single line change in `src/elements/phonemes.ts`: /æ/ nucleus weight 220 → 160.

All 256 tests pass.