### PR TITLE
🦉 Boost /ɪ/, /ɔ/, /o/ weights for I and O distribution (#162)

### DIFF
--- a/src/elements/phonemes.ts
+++ b/src/elements/phonemes.ts
@@ -55,7 +55,7 @@ export const forwardnessToPlaceOfArticulation = {
 export const phonemes: Phoneme[] = [
   // High Vowels
   { sound: "i:", mannerOfArticulation: "highVowel", tense: true, nucleus: 150, startWord: 3, midWord: 1, endWord: 8, voiced: true, placeOfArticulation: "front" }, // sheep
-  { sound: "ɪ", mannerOfArticulation: "highVowel", tense: false, nucleus: 280, startWord: 3, midWord: 8, endWord: 1, voiced: true, placeOfArticulation: "front" }, // sit
+  { sound: "ɪ", mannerOfArticulation: "highVowel", tense: false, nucleus: 280, startWord: 3, midWord: 15, endWord: 1, voiced: true, placeOfArticulation: "front" }, // sit
 
   // Mid Vowels
   { sound: "e", mannerOfArticulation: "midVowel", tense: false, nucleus: 140, startWord: 3, midWord: 2, endWord: 1, voiced: true, placeOfArticulation: "front" }, // red
@@ -67,8 +67,8 @@ export const phonemes: Phoneme[] = [
   // Low Vowels
   { sound: "æ", mannerOfArticulation: "lowVowel", tense: false, nucleus: 160, startWord: 12, midWord: 6, endWord: 1, voiced: true, placeOfArticulation: "front" }, // apple, hat, map
   { sound: "ɑ", mannerOfArticulation: "lowVowel", tense: true, nucleus: 150, startWord: 6, midWord: 2, endWord: 1, voiced: true, placeOfArticulation: "back" }, // father
-  { sound: "ɔ", mannerOfArticulation: "lowVowel", tense: true, nucleus: 80, startWord: 6, midWord: 2, endWord: 1, voiced: true, placeOfArticulation: "back" }, // ball
-  { sound: "o", mannerOfArticulation: "lowVowel", tense: true, nucleus: 100, startWord: 6, midWord: 2, endWord: 2, voiced: true, placeOfArticulation: "back" }, // hope
+  { sound: "ɔ", mannerOfArticulation: "lowVowel", tense: true, nucleus: 110, startWord: 6, midWord: 2, endWord: 1, voiced: true, placeOfArticulation: "back" }, // ball
+  { sound: "o", mannerOfArticulation: "lowVowel", tense: true, nucleus: 130, startWord: 6, midWord: 2, endWord: 2, voiced: true, placeOfArticulation: "back" }, // hope
   { sound: "ʊ", mannerOfArticulation: "highVowel", tense: true, nucleus: 100, startWord: 4, midWord: 2, endWord: 0, voiced: true, placeOfArticulation: "back" }, // book
   { sound: "u", mannerOfArticulation: "highVowel", tense: true, nucleus: 80, startWord: 4, midWord: 2, endWord: 2, voiced: true, placeOfArticulation: "back" }, // blue
   { sound: "ʌ", mannerOfArticulation: "midVowel", tense: false, nucleus: 120, startWord: 4, midWord: 2, endWord: 1, voiced: true, placeOfArticulation: "central" }, // cup


### PR DESCRIPTION
## Changes

Adjusts phoneme weights to improve I and O letter/bigram frequencies:

| Phoneme | Property | Before | After |
|---------|----------|--------|-------|
| /ɪ/ | midWord | 8 | 15 |
| /ɔ/ | nucleus | 80 | 110 |
| /o/ | nucleus | 100 | 130 |

## Results (200k word sample)

| Metric | Before | After | English | Ratio Before → After |
|--------|--------|-------|---------|---------------------|
| I letter | 6.87% | 7.58% | 7.57% | 0.91× → 1.00× ✅ |
| O letter | 6.15% | 6.62% | 7.64% | 0.81× → 0.87× |
| IN bigram | 0.885% | 0.942% | 2.43% | 0.36× → 0.39× |
| ON bigram | 0.603% | 0.675% | 1.76% | 0.34× → 0.38× |
| Letter r | 0.9378 | 0.9448 | — | improved ✅ |
| Bigram r | 0.5138 | 0.5179 | — | improved ✅ |

No regressions. All 256 tests pass.

Note: IN bigram is still well below English (0.39×). The remaining gap is primarily due to N being under-generated overall (4.78% vs 7.23%). Further IN improvement likely requires boosting N-producing phonemes (separate issue).

Closes part of #162.