### PR TITLE
fix: reduce Y-bigram over-representation (#178)

### DIFF
--- a/src/elements/graphemes/diphthongs.ts
+++ b/src/elements/graphemes/diphthongs.ts
@@ -32,6 +32,9 @@ export const diphthongGraphemes: Grapheme[] = [
     startWord: 0,
     midWord: 2,
     endWord: 5,
+    condition: {
+      notRightContext: ["consonant"],
+    },
   },
   {
     phoneme: "aɪ",
@@ -315,7 +318,7 @@ export const diphthongGraphemes: Grapheme[] = [
     frequency: 5,
     startWord: 0,
     midWord: 0,
-    endWord: 0,
+    endWord: 4,
   },
   { 
     phoneme: "eɪ", 

--- a/src/elements/graphemes/vowels.ts
+++ b/src/elements/graphemes/vowels.ts
@@ -40,6 +40,7 @@ export const vowelGraphemes: Grapheme[] = [
     endWord: 5,
     condition: {
       wordPosition: ["final"],
+      notRightContext: ["consonant"],
     },
   },
   {


### PR DESCRIPTION
## Problem

Y-bigrams were massively over-represented: yn 42×, ky 35×, yd 30× relative to English. Traced via the new `trace: true` pipeline (#182) to three root causes.

## Root Causes (trace-diagnosed)

**1. `/i:/` → "y" before coda consonants**
The "y" grapheme for /i:/ had weight 15 in final position — highest of all candidates. When a coda consonant followed, it created ugly bigrams (yr, yc, yt, yf, yg). In English, word-final "y" for /i:/ almost never has a consonant after it.

**2. `/eɪ/` → "ay" as sole survivor in final position**
All other /eɪ/ graphemes had `endWord: 0`. Position filtering killed everything except "ay", forcing 100% of word-final /eɪ/ into "ay".

**3. `/aɪ/` → "y" before coda consonants**
Same pattern as /i:/. Created yp, ym, yd bigrams.

## Fixes

1. `/i:/` "y": add `notRightContext: ["consonant"]` — blocks Y when coda follows
2. `/eɪ/` "ey": `endWord: 0 → 4` — adds "grey"/"they" as word-final alternative
3. `/aɪ/` "y": add `notRightContext: ["consonant"]` — blocks Y when coda follows

## Results (200k sample)

| Bigram | Before | After | Change |
|--------|--------|-------|--------|
| yn | 2,932 | 1,427 | -51% |
| ky | 1,121 | 531 | -53% |
| yd | 1,107 | 535 | -52% |
| yc | 960 | 482 | -50% |
| yt | 1,867 | 944 | -49% |
| ay | 7,381 | 4,934 | -33% |
| ey | 0 | 2,386 | new |
| **Y overall** | **10.9%** | **8.0%** | **-27%** |

- Phonotactic gap: unchanged (0.55)
- Performance: unchanged (8.6k words/sec)
- All 267 tests pass

Closes #178