### PR TITLE
🦉 Fix monosyllable LPP: doubling, ck, and silent-e (#209)

### DIFF
--- a/src/config/english.ts
+++ b/src/config/english.ts
@@ -155,11 +155,11 @@ export const englishConfig: LanguageConfig = {
     probability: 80,
     maxPerWord: 1,
     neverDouble: ["v", "w", "x", "y", "q", "j", "dʒ", "h", "ŋ", "θ", "ð", "ʒ"],
-    finalDoublingOnly: ["f", "s", "l", "z"],
+    finalDoublingOnly: ["f", "s", "l", "z", "k"],
     suppressAfterReduction: true,
     suppressBeforeTense: true,
     unstressedModifier: 0,
-    doubledForms: { k: 'ck' },
+    doubledForms: { k: 'ck', c: 'ck' },
     neverDoubleFinal: ['b', 'd', 'g'],
   },
 
@@ -167,22 +167,28 @@ export const englishConfig: LanguageConfig = {
     enabled: true,
     probability: 35,
     swaps: [
-      // /eɪ/ — "ai" → "a" + e (make, lake, name)
+      // /eɪ/ — "a" + e (make, lake, name); also digraph swaps
+      { phoneme: "eɪ", from: "a", to: "a" },
       { phoneme: "eɪ", from: "ai", to: "a" },
       { phoneme: "eɪ", from: "ae", to: "a" },
       { phoneme: "eɪ", from: "ea", to: "a" },
-      // /iː/ — "ee" → "e" + e (these, Pete)
+      // /iː/ — "e" + e (these, Pete); also digraph swaps
+      { phoneme: "i:", from: "e", to: "e" },
       { phoneme: "i:", from: "ee", to: "e" },
       { phoneme: "i:", from: "ea", to: "e" },
-      // /aɪ/ — "igh" → "i" + e (time, life); "ie" → "i" + e (ditto)
+      // /aɪ/ — "i" + e (time, life); also digraph swaps
+      { phoneme: "aɪ", from: "i", to: "i" },
       { phoneme: "aɪ", from: "igh", to: "i" },
       { phoneme: "aɪ", from: "ie", to: "i" },
-      // /əʊ/ — "ow" → "o" + e (home, bone)
+      // /əʊ/ — "o" + e (home, bone); also digraph swaps
+      { phoneme: "əʊ", from: "o", to: "o" },
       { phoneme: "əʊ", from: "ow", to: "o" },
       { phoneme: "əʊ", from: "oe", to: "o" },
-      // /o/ — "oa" → "o" + e (hope, note)
+      // /o/ — "o" + e (hope, note); also digraph swap
+      { phoneme: "o", from: "o", to: "o" },
       { phoneme: "o", from: "oa", to: "o" },
-      // /uː/ — "oo" → "u" + e (rude, tube); "ue" → "u" + e
+      // /uː/ — "u" + e (rude, tube); also digraph swaps
+      { phoneme: "u", from: "u", to: "u" },
       { phoneme: "u", from: "oo", to: "u" },
       { phoneme: "u", from: "ue", to: "u" },
     ],


### PR DESCRIPTION
Fixes #209 — monosyllable letters-per-phoneme was 1.115 vs CMU's 1.340.

### Doubling fixes
- Monosyllables treated as stressed (`unstressedModifier` no longer zeroes them)
- First-in-coda consonants can double even in clusters (e.g. "backs" = ck+s)
- Added `c → ck` doubling form
- Added /k/ to `finalDoublingOnly`

### Silent-e fixes
- Identity swaps for single-letter tense vowel graphemes (a, e, i, o, u)
- Allow silent-e with 1-2 coda consonants (was single-coda only)
- 2× probability boost for monosyllables

### Results (monosyllables, 200k sample)
| Metric | Before | After | CMU |
|--------|--------|-------|-----|
| Doubled cons | 0.1% | 5.8% | 11.9% |
| ck | 0.0% | 0.9% | 2.8% |
| Silent-e | 3.8% | 17.8% | 16.6% |
| LPP | 1.115 | 1.169 | 1.340 |
| Mean letters | 3.7 | 3.9 | 4.9 |

280 tests pass.