### PR TITLE
🦉 Fix GH Pages: copy demo assets to dist-demo

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -27,7 +27,6 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
-      - run: cd demo && npm run build
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/package.json
+++ b/package.json
@@ -14,9 +14,10 @@
     "lint": "eslint src/**/*.ts",
     "format": "prettier --write \"src/**/*.ts\"",
     "dev": "concurrently \"vite\" \"tsc --watch\"",
-    "build": "tsc && vite build && node scripts/inject-build-info.js && npm run copy-worker",
+    "build": "tsc && vite build && node scripts/inject-build-info.js && npm run copy-worker && npm run copy-demo-assets",
     "preview": "vite preview",
-    "copy-worker": "cp dist-demo/unglish-worker.js demo/"
+    "copy-worker": "cp dist-demo/unglish-worker.js demo/",
+    "copy-demo-assets": "cp demo/commonWordsWorker.js demo/statsWorker.js demo/matchWorker.js demo/duplicateWorker.js demo/realwords.js demo/index.js dist-demo/ 2>/dev/null || true"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Workers and realwords.js were missing from the deploy artifact. Features requiring these files (common words, stats, match) failed to load on https://unglish.github.io/word-generator/

- Added `copy-demo-assets` build step
- Removed broken `cd demo && npm run build` from deploy workflow