### PR TITLE
🦉 Use CMU dictionary baseline for demo length chart

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -386,7 +386,7 @@
                 }
                 $('len-chart').innerHTML = html;
                 const avgLen = (lexWords.reduce((s,w) => s + w.written.clean.length, 0) / lexWords.length).toFixed(1);
-                $('len-ref').textContent = 'Unglish avg: ' + avgLen + ' letters · English avg: ~4.7 (running text), ~8.5 (dictionary)';
+                $('len-ref').textContent = 'Unglish avg: ' + avgLen + ' letters · English dictionary avg: ~7.6';
             }
 
             // Letter frequency
@@ -529,7 +529,8 @@
             const engLetterOrder = ['e','t','a','o','i','n','s','r','h','l','d','c','u','m','f','p','g','w','y','b','v','k','x','j','q','z'];
             const engBigrams = {th:3.56,he:3.07,in:2.43,er:2.05,an:1.99,re:1.85,on:1.76,at:1.49,en:1.45,nd:1.35,ti:1.34,es:1.34,or:1.28,te:1.27,of:1.17,ed:1.17,is:1.13,it:1.12,al:1.09,ar:1.07};
             const engBigramOrder = ['th','he','in','er','an','re','on','at','en','nd','ti','es','or','te','of','ed','is','it','al','ar'];
-            const engLengthDist = {1:2.5,2:14.8,3:22.7,4:17.6,5:12.4,6:10.1,7:7.6,8:5.4,9:3.5,10:1.8,11:0.9,12:0.4,13:0.3};
+            // CMU Pronouncing Dictionary baseline (unique words, lexicon mode)
+            const engLengthDist = {1:0,2:0.2,3:1.3,4:5.6,5:12.4,6:18.3,7:18.9,8:15.2,9:11.2,10:7.5,11:4.4,12:2.5,13:2.4};
 
             function pearsonR(xs, ys) {
                 const n = xs.length;


### PR DESCRIPTION
The demo generates in lexicon mode but compared against text-frequency distributions where 'the', 'and' etc. dominate. Now uses CMU dictionary baseline which matches the generation mode.