### PR TITLE
feat: CMU dictionary baselines for bigram & trigram stats

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -525,11 +525,16 @@
 
             // ===== STATS TAB =====
 
-            const engLetterFreq = {e:12.49,t:9.28,a:8.04,o:7.60,i:7.57,n:7.23,s:6.51,r:6.28,h:5.05,l:4.07,d:3.82,c:3.34,u:2.73,m:2.51,f:2.40,p:2.14,g:1.87,w:1.68,y:1.66,b:1.48,v:1.05,k:0.54,x:0.23,j:0.16,q:0.12,z:0.09};
-            const engLetterOrder = ['e','t','a','o','i','n','s','r','h','l','d','c','u','m','f','p','g','w','y','b','v','k','x','j','q','z'];
-            const engBigrams = {th:3.56,he:3.07,in:2.43,er:2.05,an:1.99,re:1.85,on:1.76,at:1.49,en:1.45,nd:1.35,ti:1.34,es:1.34,or:1.28,te:1.27,of:1.17,ed:1.17,is:1.13,it:1.12,al:1.09,ar:1.07};
-            const engBigramOrder = ['th','he','in','er','an','re','on','at','en','nd','ti','es','or','te','of','ed','is','it','al','ar'];
-            const engLengthDist = {1:2.5,2:14.8,3:22.7,4:17.6,5:12.4,6:10.1,7:7.6,8:5.4,9:3.5,10:1.8,11:0.9,12:0.4,13:0.3};
+            // CMU Pronouncing Dictionary baseline (unique words, lexicon mode)
+            const engLetterFreq = {e:11.46,a:8.80,r:7.76,i:7.65,n:7.28,s:6.92,o:6.42,t:5.85,l:5.83,c:3.91,d:3.52,m:3.11,u:3.07,h:2.88,g:2.77,p:2.29,b:2.25,k:1.80,y:1.60,f:1.39,w:1.10,v:1.05,z:0.65,j:0.26,x:0.23,q:0.14};
+            const engLetterOrder = ['e','a','r','i','n','s','o','t','l','c','d','m','u','h','g','p','b','k','y','f','w','v','z','j','x','q'];
+            // CMU Pronouncing Dictionary baselines (unique words, lexicon mode)
+            const engBigrams = {er:2.71,in:2.16,an:1.72,on:1.42,en:1.35,re:1.32,le:1.31,ar:1.30,es:1.29,te:1.28,st:1.10,ng:1.07,ra:1.05,ti:1.04,al:1.01,ri:1.00,el:1.00,at:0.99,ne:0.95,or:0.95};
+            const engBigramOrder = ['er','in','an','on','en','re','le','ar','es','te','st','ng','ra','ti','al','ri','el','at','ne','or'];
+            const engTrigrams = {ing:1.02,ter:0.45,ers:0.42,ion:0.42,man:0.40,ati:0.35,ent:0.34,ell:0.33,lin:0.32,ate:0.32,tio:0.32,and:0.28,ste:0.28,tin:0.26,all:0.26,ber:0.25,der:0.25,ine:0.25,ill:0.25,che:0.24};
+            const engTrigramOrder = ['ing','ter','ers','ion','man','ati','ent','ell','lin','ate','tio','and','ste','tin','all','ber','der','ine','ill','che'];
+            // CMU Pronouncing Dictionary baseline (unique words, lexicon mode)
+            const engLengthDist = {1:0,2:0.2,3:1.3,4:5.2,5:11.5,6:17.4,7:18.6,8:15.5,9:11.7,10:8.1,11:4.8,12:2.7,13:2.4};
 
             function pearsonR(xs, ys) {
                 const n = xs.length;
@@ -576,7 +581,7 @@
                 const engLetterPcts = engLetterOrder.map(ch => engLetterFreq[ch]);
                 const letterR = pearsonR(genLetterPcts, engLetterPcts);
                 $('stats-letter-r').textContent = 'Pearson r = ' + letterR.toFixed(4);
-                $('stats-letter-legend').innerHTML = '<span style="display:inline-block;width:0.8em;height:0.8em;background:steelblue;vertical-align:middle"></span> Generated &nbsp; <span style="display:inline-block;width:0.8em;height:0.8em;background:darkgrey;vertical-align:middle"></span> English';
+                $('stats-letter-legend').innerHTML = '<span style="display:inline-block;width:0.8em;height:0.8em;background:steelblue;vertical-align:middle"></span> Generated &nbsp; <span style="display:inline-block;width:0.8em;height:0.8em;background:darkgrey;vertical-align:middle"></span> CMU Dictionary';
                 $('stats-letter-chart').innerHTML = engLetterOrder.map((ch, idx) => {
                     const gen = genLetterPcts[idx];
                     const eng = engLetterPcts[idx];
@@ -605,13 +610,42 @@
                 const engBigramPcts = engBigramOrder.map(bg => engBigrams[bg]);
                 const bigramR = pearsonR(genBigramPcts, engBigramPcts);
                 $('stats-bigram-r').textContent = 'Pearson r = ' + bigramR.toFixed(4);
-                $('stats-bigram-legend').innerHTML = '<span style="display:inline-block;width:0.8em;height:0.8em;background:steelblue;vertical-align:middle"></span> Generated &nbsp; <span style="display:inline-block;width:0.8em;height:0.8em;background:darkgrey;vertical-align:middle"></span> English';
+                $('stats-bigram-legend').innerHTML = '<span style="display:inline-block;width:0.8em;height:0.8em;background:steelblue;vertical-align:middle"></span> Generated &nbsp; <span style="display:inline-block;width:0.8em;height:0.8em;background:darkgrey;vertical-align:middle"></span> CMU Dictionary';
                 $('stats-bigram-chart').innerHTML = engBigramOrder.map((bg, idx) => {
                     const gen = genBigramPcts[idx];
                     const eng = engBigramPcts[idx];
                     const wG = (gen / maxBigramPct * 100).toFixed(1);
                     const wE = (eng / maxBigramPct * 100).toFixed(1);
                     return '<div class="freq-row"><div class="freq-letter" style="width:2.5em">' + bg.toUpperCase() + '</div><div class="freq-bars">' +
+                        '<div class="freq-bar" style="width:' + wG + '%;background:steelblue"></div>' +
+                        '<div class="freq-bar" style="width:' + wE + '%;background:darkgrey"></div>' +
+                        '</div><div class="freq-val">' + gen.toFixed(2) + ' / ' + eng.toFixed(2) + '</div></div>';
+                }).join('');
+
+                // Trigram frequency
+                const trigramCounts = {};
+                let totalTrigrams = 0;
+                for (const w of words) {
+                    const lw = w.toLowerCase();
+                    for (let i = 0; i < lw.length - 2; i++) {
+                        const tg = lw[i] + lw[i+1] + lw[i+2];
+                        if (tg[0] >= 'a' && tg[0] <= 'z' && tg[1] >= 'a' && tg[1] <= 'z' && tg[2] >= 'a' && tg[2] <= 'z') {
+                            trigramCounts[tg] = (trigramCounts[tg] || 0) + 1; totalTrigrams++;
+                        }
+                    }
+                }
+                const maxTrigramPct = 2;
+                const genTrigramPcts = engTrigramOrder.map(tg => totalTrigrams ? (trigramCounts[tg] || 0) / totalTrigrams * 100 : 0);
+                const engTrigramPcts = engTrigramOrder.map(tg => engTrigrams[tg]);
+                const trigramR = pearsonR(genTrigramPcts, engTrigramPcts);
+                $('stats-trigram-r').textContent = 'Pearson r = ' + trigramR.toFixed(4);
+                $('stats-trigram-legend').innerHTML = '<span style="display:inline-block;width:0.8em;height:0.8em;background:steelblue;vertical-align:middle"></span> Generated &nbsp; <span style="display:inline-block;width:0.8em;height:0.8em;background:darkgrey;vertical-align:middle"></span> CMU Dictionary';
+                $('stats-trigram-chart').innerHTML = engTrigramOrder.map((tg, idx) => {
+                    const gen = genTrigramPcts[idx];
+                    const eng = engTrigramPcts[idx];
+                    const wG = (gen / maxTrigramPct * 100).toFixed(1);
+                    const wE = (eng / maxTrigramPct * 100).toFixed(1);
+                    return '<div class="freq-row"><div class="freq-letter" style="width:2.5em">' + tg.toUpperCase() + '</div><div class="freq-bars">' +
                         '<div class="freq-bar" style="width:' + wG + '%;background:steelblue"></div>' +
                         '<div class="freq-bar" style="width:' + wE + '%;background:darkgrey"></div>' +
                         '</div><div class="freq-val">' + gen.toFixed(2) + ' / ' + eng.toFixed(2) + '</div></div>';
@@ -769,7 +803,7 @@
         </div>
         <div id="content-stats" class="tab-content">
             <div class="card">
-                <h2>Letter Frequency — Generated vs English</h2>
+                <h2>Letter Frequency — Generated vs CMU Dictionary</h2>
                 <button class="refresh" id="refresh-stats" title="Regenerate">&#x21bb;</button>
                 <div id="stats-status" class="stat-line">Click Regenerate or switch to this tab to generate 10,000 words.</div>
                 <div id="stats-letter-r" style="font-size:1.1em;font-weight:bold;margin:0.5em 0"></div>
@@ -778,14 +812,21 @@
             </div>
 
             <div class="card">
-                <h2>Bigram Frequency — Generated vs English</h2>
+                <h2>Bigram Frequency — Generated vs CMU Dictionary</h2>
                 <div id="stats-bigram-r" style="font-size:1.1em;font-weight:bold;margin:0.5em 0"></div>
                 <div class="legend" id="stats-bigram-legend"></div>
                 <div id="stats-bigram-chart"></div>
             </div>
 
             <div class="card">
-                <h2>Word Length Distribution — Generated vs English</h2>
+                <h2>Trigram Frequency — Generated vs CMU Dictionary</h2>
+                <div id="stats-trigram-r" style="font-size:1.1em;font-weight:bold;margin:0.5em 0"></div>
+                <div class="legend" id="stats-trigram-legend"></div>
+                <div id="stats-trigram-chart"></div>
+            </div>
+
+            <div class="card">
+                <h2>Word Length Distribution — Generated vs CMU Dictionary</h2>
                 <div id="stats-length-chart"></div>
                 <div class="legend" id="stats-length-legend"></div>
             </div>

--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
+set -e
 # Rebuild demo and deploy to local nginx
-cd "$(git rev-parse --show-toplevel)/demo"
+cd "$(git rev-parse --show-toplevel)"
 npm run build
-sudo cp -r ../dist-demo/* /var/www/html/
+sudo cp -r dist-demo/* /var/www/html/
+sudo mkdir -p /var/www/html/demo
+sudo cp -r dist-demo/* /var/www/html/demo/
 echo "Demo deployed to localhost ($(git rev-parse --short HEAD))"


### PR DESCRIPTION
## Changes
- Replace text-frequency bigram baseline with CMU dictionary baseline (matches lexicon generation mode)
- Add trigram frequency chart with top 20 CMU trigrams and Pearson r correlation
- Update all n-gram labels to 'CMU Dictionary' for consistency with length distribution chart

Key difference: text-frequency top bigrams are TH, HE, IN (driven by common words like 'the', 'he'). CMU dictionary top bigrams are ER, IN, AN — which better reflects the distribution our lexicon generator should match.

Refs #209