### PR TITLE
🦉 Fix phoneme-length distribution skew in lexicon mode (#221)

### DIFF
--- a/scripts/phoneme-length-dist.ts
+++ b/scripts/phoneme-length-dist.ts
@@ -1,0 +1,59 @@
+/**
+ * Measure phoneme-length distribution of 200k generated words (lexicon mode)
+ * vs CMU dictionary baseline.
+ *
+ * Usage: npx tsx scripts/phoneme-length-dist.ts
+ */
+import { generateWord } from '../src/core/generate.js';
+import { readFileSync } from 'fs';
+
+const N = 200_000;
+
+// --- CMU baseline ---
+const cmuLines = readFileSync('data/cmudict-0.7b.txt', 'utf8').split('\n');
+const cmuCounts: Record<number, number> = {};
+let cmuTotal = 0;
+for (const line of cmuLines) {
+  if (!line || line.startsWith(';;;')) continue;
+  const spaceIdx = line.indexOf(' ');
+  if (spaceIdx < 0) continue;
+  // skip alternate pronunciations (word(2))
+  const wordPart = line.slice(0, spaceIdx);
+  if (/\(\d+\)$/.test(wordPart)) continue;
+  const phonemes = line.slice(spaceIdx + 1).trim().split(/\s+/);
+  const len = phonemes.length;
+  cmuCounts[len] = (cmuCounts[len] ?? 0) + 1;
+  cmuTotal++;
+}
+
+// --- Generated ---
+const genCounts: Record<number, number> = {};
+for (let i = 0; i < N; i++) {
+  const w = generateWord({ seed: i, mode: 'lexicon' });
+  let len = 0;
+  for (const syl of w.syllables) {
+    len += syl.onset.length + syl.nucleus.length + syl.coda.length;
+  }
+  genCounts[len] = (genCounts[len] ?? 0) + 1;
+}
+
+// --- Print ---
+const allKeys = new Set([
+  ...Object.keys(cmuCounts).map(Number),
+  ...Object.keys(genCounts).map(Number),
+]);
+const sorted = [...allKeys].sort((a, b) => a - b);
+
+console.log('phonemes | generated% | cmu%   | delta');
+console.log('---------|------------|--------|------');
+for (const k of sorted) {
+  if (k < 1 || k > 16) continue;
+  const gPct = ((genCounts[k] ?? 0) / N * 100);
+  const cPct = ((cmuCounts[k] ?? 0) / cmuTotal * 100);
+  const delta = gPct - cPct;
+  console.log(
+    `${String(k).padEnd(8)} | ${gPct.toFixed(2).padEnd(10)} | ${cPct.toFixed(2).padEnd(6)} | ${delta >= 0 ? '+' : ''}${delta.toFixed(2)}`
+  );
+}
+console.log(`\nGenerated: ${N.toLocaleString()} words`);
+console.log(`CMU:       ${cmuTotal.toLocaleString()} entries`);

--- a/src/config/weights.ts
+++ b/src/config/weights.ts
@@ -169,8 +169,8 @@ export const SYLLABLE_COUNT_WEIGHTS_TEXT: [number, number][] = [
  */
 export const SYLLABLE_COUNT_WEIGHTS_LEXICON: [number, number][] = [
   [1, 12900],  // 12.9%
-  [2, 46000],  // 46.0%
-  [3, 27600],  // 27.6%
+  [2, 41000],  // 41.0% (was 46000 — shifted 5k to 3-syl to fix phoneme-length skew)
+  [3, 32600],  // 32.6% (was 27600)
   [4, 10000],  // 10.0%
   [5, 3840],   //  3.8% (compensate for rejection sampling)
   [6, 550],    //  0.55%


### PR DESCRIPTION
## Summary

Shifts `SYLLABLE_COUNT_WEIGHTS_LEXICON` to reduce 2-syl weight and increase 3-syl weight, bringing phoneme-length distribution closer to the CMU dictionary baseline.

**Weight change:** 2-syl 46000→41000, 3-syl 27600→32600

Also adds `scripts/phoneme-length-dist.ts` for measuring 200k sample phoneme-length distribution against CMU.

## Results (200k sample)

| Phonemes | Before | After | CMU | Δ After |
|----------|--------|-------|-----|---------|
| 4 | +2.76 | +0.77 | 12.55% | ✅ |
| 5 | +2.36 | -0.16 | 19.55% | ✅ |
| **6** | **-3.01** | **-3.34** | **20.38%** | ❌ known gap |
| 7 | -1.75 | -0.50 | 15.58% | ✅ |
| 8 | -1.09 | +0.25 | 11.17% | ✅ |

All buckets within ±1.5% of CMU **except** 6-phoneme (-3.3%). This gap is structural — 2-syl words don't generate enough complex consonant clusters, and the current weight architecture applies uniformly across syllable counts, making it impossible to target 6-phoneme 2-syl words specifically without destabilising other buckets.

## Known Limitation

The 6-phoneme gap will be addressed by a planned refactor to top-down phoneme-length-targeted generation (see linked issue). Accepting the gap for now as it's a single bucket at -3.3pp.

Closes #221
