### PR TITLE
🦉 Increase stats page sample size from 10k to 200k

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -518,17 +518,19 @@
             }
 
             function runStats() {
-                $('stats-status').textContent = 'Generating 10,000 words...';
+                $('stats-status').textContent = 'Generating 200,000 words...';
                 if (statsWorker) statsWorker.terminate();
                 statsWorker = new Worker('statsWorker.js?v=' + Date.now());
                 statsWorker.onmessage = function(ev) {
-                    if (ev.data.type === 'stats') {
+                    if (ev.data.type === 'progress') {
+                        $('stats-status').textContent = 'Generating 200,000 words... ' + ev.data.done.toLocaleString() + '/' + ev.data.total.toLocaleString();
+                    } else if (ev.data.type === 'stats') {
                         renderStats(ev.data.words, ev.data.phonemes);
                         statsWorker.terminate();
                         statsWorker = null;
                     }
                 };
-                statsWorker.postMessage({ action: 'generateStats', count: 10000 });
+                statsWorker.postMessage({ action: 'generateStats', count: 200000 });
             }
 
             // Paginated chart helper

--- a/demo/statsWorker.js
+++ b/demo/statsWorker.js
@@ -2,7 +2,8 @@ importScripts('./unglish-worker.js');
 
 onmessage = function(e) {
   if (e.data.action === 'generateStats') {
-    const count = e.data.count || 10000;
+    const count = e.data.count || 200000;
+    const PROGRESS_EVERY = 10000;
     const words = [];
     const phonemes = [];
     for (let i = 0; i < count; i++) {
@@ -14,6 +15,9 @@ onmessage = function(e) {
         });
       });
       phonemes.push(sounds);
+      if ((i + 1) % PROGRESS_EVERY === 0 && (i + 1) < count) {
+        postMessage({ type: 'progress', done: i + 1, total: count });
+      }
     }
     postMessage({ type: 'stats', words: words, phonemes: phonemes });
   }


### PR DESCRIPTION
## Summary

The stats page was sampling only 10,000 words. Bumped to 200,000 for much more reliable n-gram and frequency distributions.

### Changes

- **`demo/index.html`**: Update count `10000 → 200000`, status text, and handle `progress` events from worker
- **`demo/statsWorker.js`**: Update default count; emit `{ type: 'progress', done, total }` every 10k iterations so the UI shows a live counter instead of freezing

### UX

Status bar now updates as generation proceeds:
> *Generating 200,000 words... 50,000/200,000*

rather than appearing hung for several seconds.