### PR TITLE
🦉 fix: /ŋk/ writes as 'nk' not 'ngc' (bank, think, drink)

### DIFF
--- a/src/config/english.ts
+++ b/src/config/english.ts
@@ -224,6 +224,13 @@ export const englishConfig: LanguageConfig = {
 
   spellingRules: [
     {
+      name: "nc-to-nk",
+      pattern: "nc(?=[^eiyaouhlr]|$)",
+      replacement: "nk",
+      probability: 100,
+      scope: "word",
+    },
+    {
       name: "magic-e",
       pattern: "([aiouy])e([bcdfghjklmnpqrstvwxyz])$",
       replacement: "$1$2e",

--- a/src/elements/graphemes/nasals.ts
+++ b/src/elements/graphemes/nasals.ts
@@ -107,5 +107,19 @@ export const nasalGraphemes: Grapheme[] = [
     startWord: 0,
     midWord: 1,
     endWord: 1,
+    condition: { notRightContext: ["k", "g"] },
+  },
+  {
+    // /ŋ/ before velar stops writes as "n" (think, bank, anger)
+    phoneme: "ŋ",
+    form: "n",
+    origin: 0,
+    frequency: 100,
+    onset: 0,
+    cluster: 0,
+    startWord: 0,
+    midWord: 1,
+    endWord: 0,
+    condition: { rightContext: ["k", "g"] },
   }
 ];

--- a/src/elements/graphemes/stops.ts
+++ b/src/elements/graphemes/stops.ts
@@ -98,6 +98,16 @@ export const stopGraphemes: Grapheme[] = [
     endWord: 1,
     condition: { rightContext: ["c-soft-vowel"] },
   },
+  // k: after "n" — /ŋk/ writes as "nk" (bank, think, drink)
+  { phoneme: "k",
+    form: "k",
+    origin: 3,
+    frequency: 500,
+    startWord: 0,
+    midWord: 80,
+    endWord: 80,
+    condition: { leftGraphemeContext: ["n"] },
+  },
   // k: word-final (speak, back)
   { phoneme: "k", 
     form: "k", 


### PR DESCRIPTION
## Problem

The /ŋk/ phoneme sequence (as in "bank", "think", "drink") was being written as "ngc" or "ngcs" — producing the phantom trigram `gcs` at 312 occurrences per 200k words. This is because:
- /ŋ/ only had one grapheme: "ng"
- /k/ defaulted to "c" (frequency 300 vs "k" at 5)
- Result: "ng" + "c" + "s" = "ngcs"

In English, /ŋ/ before velar stops is always written "n": bank, think, anger, finger.

## Fix

1. **Grapheme**: Split /ŋ/ — "ng" gets `notRightContext: ["k","g"]`, new "n" variant gets `rightContext: ["k","g"]`
2. **Grapheme**: Add /k/ → "k" with `leftGraphemeContext: ["n"]` (high freq) to prefer "nk" over "nc"
3. **Spelling rule**: `nc(?=[^eiyaouhlr]|$)` → `nk` — catches residual "nc" competition, preserves "nce"/"nci"/"nch"

## Results (50k words, seed 42)

| Metric | Before | After |
|--------|--------|-------|
| `gcs` trigrams | ~80 | **0** |
| /ŋk/ as "nk" | 12 | **420** |
| /ŋk/ as "nc" (bad) | 428 | **3** |

Example words: dank, spanks, clonk, hank, jank, mink, sink, thrinks