### PR TITLE
🦉 Simplify ew/ow before consonant clusters

### DIFF
--- a/src/config/english.ts
+++ b/src/config/english.ts
@@ -238,6 +238,20 @@ export const englishConfig: LanguageConfig = {
       scope: "syllable",
     },
     {
+      name: "ew-cluster-simplify",
+      pattern: "ew(?=[bcdfghjklmnpqrstvwxyz]{2})",
+      replacement: "u",
+      probability: 100,
+      scope: "syllable",
+    },
+    {
+      name: "ow-cluster-simplify",
+      pattern: "ow(?=[bcdfghjklmnpqrstvwxyz]{2})",
+      replacement: "ou",
+      probability: 100,
+      scope: "syllable",
+    },
+    {
       name: "ks-to-x",
       pattern: "(?<!^)ks",
       replacement: "x",


### PR DESCRIPTION
## Problem
Vowel digraphs `ew` (for /u/) and `ow` (for /aʊ/, /əʊ/) followed by 2+ consonant codas produce impossible `wCC` trigrams:

- `ewms` (127×), `ewcs` (85×), `ewmb` (65×), `ewnk` (51×), `ewct` (49×)
- `owms`, `owlm`, `owlc`, `owfs`, etc.

These never appear in English. Words like `lewms` (/lumz/) should be `lums`; `hewmp` (/hump/) should be `hump`.

## Root Cause
In English, `ew` for /u/ only appears before simple codas: new, few, brew, flew, stew. Never \*ewm, \*ewf, \*ewl.

Similarly, `ow` before complex clusters should be `ou`: bound/found/mount, not \*bownd/\*mownt.

## Fix
Two syllable-scope spelling rules:

| Rule | Pattern | Replacement | Probability |
|------|---------|-------------|-------------|
| `ew-cluster-simplify` | `ew(?=[CONS]{2})` | `u` | 100% |
| `ow-cluster-simplify` | `ow(?=[CONS]{2})` | `ou` | 100% |

Applied at syllable scope before join, so they only affect vowel+coda within a single syllable.

## Results
| Metric | Before | After | Change |
|--------|--------|-------|--------|
| w-cluster phantom trigrams | ~730 | ~0 | **eliminated** |
| Total CCC phantoms (200k) | 2,749 | 2,084 | **-24%** |

## What Remains
The remaining ~2,084 CCC phantoms are cross-syllable boundary sequences (e.g., `ctp` from /kt/ coda + /p/ onset) — a fundamentally different problem that would require write pipeline changes, not spelling rules.