### PR TITLE
refactor: Phase C — validateJunction as single public API (#250)

### DIFF
--- a/src/core/generate.ts
+++ b/src/core/generate.ts
@@ -4,7 +4,7 @@ import getWeightedOption from "../utils/getWeightedOption.js";
 import { LanguageConfig, computeSonorityLevels, validateConfig, ClusterLimits, SonorityConstraints } from "../config/language.js";
 import { englishConfig } from "../config/english.js";
 import { applyStress, generatePronunciation } from "./pronounce.js";
-import { createWrittenFormGenerator, isJunctionSonorityValid } from "./write.js";
+import { createWrittenFormGenerator, validateJunction } from "./write.js";
 import { repairClusters, repairFinalCoda, repairClusterShape, repairHAfterBackVowel } from "./repair.js";
 import { repairStressedNuclei } from "./stress-repair.js";
 import { planMorphology, applyMorphology } from "./morphology/index.js";
@@ -664,13 +664,13 @@ function adjustBoundary(rt: GeneratorRuntime, prevSyllable: Syllable, currentSyl
   //
   // maxDrops is computed *after* check 1 may have already popped one phoneme —
   // it serves as an upper bound so the loop can't run forever. The explicit
-  // `coda.length === 0` guard is here for clarity: isJunctionSonorityValid
-  // returns true for an empty coda anyway, so the loop would terminate on the
-  // next iteration without it, but the early break makes intent clear.
+  // `coda.length === 0` guard is here for clarity: validateJunction returns
+  // true for an empty coda anyway, so the loop would terminate on the next
+  // iteration without it, but the early break makes intent clear.
   const maxDrops = prevSyllable.coda.length;
   for (let d = 0; d < maxDrops; d++) {
     if (prevSyllable.coda.length === 0) break;
-    if (isJunctionSonorityValid(prevSyllable.coda, currentSyllable.onset, rt.config)) break;
+    if (validateJunction(prevSyllable.coda, currentSyllable.onset, rt.config)) break;
     const dropped = prevSyllable.coda.pop()!;
     // TODO(#250): Trace message shows post-drop coda, which is correct for
     // "remaining cluster" but could be confusing. Consider showing before/after.

--- a/src/core/write.ts
+++ b/src/core/write.ts
@@ -754,6 +754,8 @@ export function repairConsonantPileups(
  *
  * Exception: /s/ can violate SSP (e.g. "str", "sp", "sts") — the s-exception
  * is well-attested across languages.
+ *
+ * @internal Use {@link validateJunction} as the public API.
  */
 export function isJunctionSonorityValid(
   coda: Phoneme[],
@@ -874,7 +876,11 @@ export function validateJunction(
   return true;
 }
 
-/** Pairwise articulatory junction check (coda-final vs onset-initial). */
+/**
+ * Pairwise articulatory junction check (coda-final vs onset-initial).
+ *
+ * @internal Use {@link validateJunction} as the public API.
+ */
 export function isJunctionValid(C1: Phoneme, C2: Phoneme, onsetCluster: Phoneme[]): boolean {
   // F1: identical phonemes
   if (C1.sound === C2.sound) return false;
@@ -920,7 +926,7 @@ export function repairJunctions(
   hyphenatedParts: string[],
   boundaries: SyllableBoundary[],
   consonantGraphemes?: string[],
-  config?: LanguageConfig, // optional for backward compat; SSP check skipped without it
+  config: LanguageConfig,
 ): void {
   const gList = consonantGraphemes ?? DEFAULT_CONSONANT_GRAPHEMES;
 
@@ -930,11 +936,7 @@ export function repairJunctions(
       const { onsetCluster, codaCluster } = boundaries[i];
       if (codaCluster.length === 0 || onsetCluster.length === 0) continue;
 
-      const invalid = config
-        ? !validateJunction(codaCluster, onsetCluster, config)
-        : codaCluster.length > 0 && onsetCluster.length > 0
-          && !isJunctionValid(codaCluster[codaCluster.length - 1], onsetCluster[0], onsetCluster);
-      if (invalid) {
+      if (!validateJunction(codaCluster, onsetCluster, config)) {
         // Drop the last consonant grapheme token from the coda part
         const codaPart = cleanParts[i];
         if (!codaPart) continue;


### PR DESCRIPTION
## What

Phase C of #250: consolidate the junction validation API.

## Changes

- **`generate.ts`** — `adjustBoundary` now calls `validateJunction` instead of `isJunctionSonorityValid` directly. This means the upstream phoneme-drop loop now also benefits from the articulatory rules (F1–F4, P1–P5), not just SSP.
- **`write.ts`** — `config` parameter on `repairJunctions` is now required (was optional for backward compat). The fallback code path that called `isJunctionValid` directly is removed.
- **`write.ts`** — `isJunctionValid` and `isJunctionSonorityValid` marked `@internal` with a pointer to `validateJunction`. Still exported for unit tests.

## What stays the same

- All 116 unit tests pass unchanged.
- `isJunctionValid` and `isJunctionSonorityValid` remain exported (needed for their own unit test suites); they're just no longer the intended call sites for callers outside `write.ts`.